### PR TITLE
Add warmup controller and application initialization

### DIFF
--- a/src/EA.Iws.Api/Controllers/WarmupController.cs
+++ b/src/EA.Iws.Api/Controllers/WarmupController.cs
@@ -1,0 +1,56 @@
+﻿namespace EA.Iws.Api.Controllers
+{
+    using System.Data.Entity;
+    using System.Threading.Tasks;
+    using System.Web.Http;
+    using DataAccess;
+    using DataAccess.Filestore;
+    using DataAccess.Identity;
+
+    [AllowAnonymous]
+    [RoutePrefix("api/warmup")]
+    public class WarmupController : ApiController
+    {
+        private readonly IwsContext iwsContext;
+        private readonly ImportNotificationContext importNotificationContext;
+        private readonly IwsFileStoreContext fileStoreContext;
+        private readonly IwsIdentityContext identityContext;
+
+        public WarmupController(IwsContext iwsContext, ImportNotificationContext importNotificationContext,
+            IwsFileStoreContext fileStoreContext, IwsIdentityContext identityContext)
+        {
+            this.iwsContext = iwsContext;
+            this.importNotificationContext = importNotificationContext;
+            this.fileStoreContext = fileStoreContext;
+            this.identityContext = identityContext;
+        }
+
+        [HttpGet]
+        [Route("")]
+        public async Task<IHttpActionResult> Get()
+        {
+            // Warmup Entity Framework contexts by making a query
+            if (iwsContext.Database.Exists())
+            {
+                await iwsContext.NotificationApplications.FirstOrDefaultAsync();
+            }
+
+            if (importNotificationContext.Database.Exists())
+            {
+                await importNotificationContext.ImportNotifications.FirstOrDefaultAsync();
+            }
+
+            if (fileStoreContext.Database.Exists())
+            {
+                await fileStoreContext.Files.FirstOrDefaultAsync();
+            }
+
+            if (identityContext.Database.Exists())
+            {
+                await identityContext.Users.FirstOrDefaultAsync();
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/src/EA.Iws.Api/EA.Iws.Api.csproj
+++ b/src/EA.Iws.Api/EA.Iws.Api.csproj
@@ -249,6 +249,7 @@
     <Compile Include="App_Start\Modules\EmailServiceModule.cs" />
     <Compile Include="App_Start\Modules\UserContextModule.cs" />
     <Compile Include="Controllers\ErrorLogController.cs" />
+    <Compile Include="Controllers\WarmupController.cs" />
     <Compile Include="IdSrv\AspNetIdentityUserService.cs" />
     <Compile Include="IdSrv\ClaimsTransformationOptionsFactory.cs" />
     <Compile Include="Infrastructure\ElmahSqlLogger.cs" />

--- a/src/EA.Iws.Api/Web.config
+++ b/src/EA.Iws.Api/Web.config
@@ -130,6 +130,9 @@
     </assemblyBinding>
   </runtime>
   <system.webServer>
+    <applicationInitialization doAppInitAfterRestart="true">
+      <add initializationPage="api/warmup" />
+    </applicationInitialization>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />
@@ -168,5 +171,31 @@
       <add type="Elmah.SqlErrorLog, Elmah" connectionStringName="Iws.DefaultConnection" />
       <add type="Elmah.XmlFileErrorLog, Elmah" logPath="~/App_Data" />
     </errorLog>
+      <errorFilter>
+      <test>
+        <jscript>
+          <expression>
+            <![CDATA[
+            // @assembly mscorlib
+            // @import System
+            // @import System.Threading.Tasks
+            
+            // Root requests made by the IIS Application Initialization Preload that may cause
+            // exceptions to be raised. This originally specified TaskCanceledExceptions, but the
+            // exception type has altered since IdentityServer updates. It may be beneficial to investigate
+            // and re-specify the type in the future.
+            ($.Context.Request.Path.match(/^\/$/)
+             && $.Context.Request.UserAgent.match(/\bIIS\s+Application\s+Initialization\s+Preload\b/i))
+             ||
+            // /warmup requests made by the IIS Application Initialization Warmup that may cause
+            // OperationCanceledException to be raised      
+            ($.BaseException instanceof OperationCanceledException
+             && $.Context.Request.Path.match(/^\/warmup$/)
+             && $.Context.Request.UserAgent.match(/\bIIS\s+Application\s+Initialization\s+Warmup\b/i))
+            ]]>
+          </expression>
+        </jscript>
+      </test>
+</errorFilter>
   </elmah>
 </configuration>


### PR DESCRIPTION
Application initialization is required so HangFire can run 24/7. As we need the mechanism we can take advantage and warm up the Entity Framework contexts too.