### PR TITLE
Fix Payment Received Date on Key Dates Screeen - SFW24890 

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/NotificationAssessmentDatesSummaryRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/NotificationAssessmentDatesSummaryRepository.cs
@@ -33,19 +33,20 @@
             var assessment = await notificationAssessmentRepository.GetByNotificationId(notificationId);
             var notification = await notificationApplicationRepository.GetById(notificationId);
 
-            var latestPayment = await transactionCalculator.LatestPayment(notificationId);
-            DateTime? lastestPaymentDate = null;
+            var paymentReceived = await transactionCalculator.PaymentReceivedDate(notificationId) ??
+                                      await transactionCalculator.LatestPayment(notificationId);
+            DateTime? paymentReceivedDate = null;
 
-            if (latestPayment != null)
+            if (paymentReceived != null)
             {
-                lastestPaymentDate = latestPayment.Date;
+                paymentReceivedDate = paymentReceived.Date;
             }
 
             return NotificationDatesSummary.Load(
                 assessment.Status,
                 assessment.Dates.NotificationReceivedDate,
                 notificationId,
-                lastestPaymentDate,
+                paymentReceivedDate,
                 await transactionCalculator.IsPaymentComplete(notificationId),
                 assessment.Dates.CommencementDate,
                 assessment.Dates.NameOfOfficer,

--- a/src/EA.Iws.Domain/NotificationAssessment/INotificationTransactionCalculator.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/INotificationTransactionCalculator.cs
@@ -11,6 +11,8 @@ namespace EA.Iws.Domain.NotificationAssessment
 
         Task<NotificationTransaction> LatestPayment(Guid notificationId);
 
+        Task<NotificationTransaction> PaymentReceivedDate(Guid notificationId);
+
         Task<decimal> RefundLimit(Guid notificationId);
 
         Task<decimal> TotalPaid(Guid notificationId);

--- a/src/EA.Iws.Domain/NotificationAssessment/NotificationTransactionCalculator.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/NotificationTransactionCalculator.cs
@@ -50,6 +50,28 @@
             return transactions.Where(t => t.Credit > 0).OrderByDescending(t => t.Date).FirstOrDefault();
         }
 
+        public async Task<NotificationTransaction> PaymentReceivedDate(Guid notificationId)
+        {
+            var balance = await Balance(notificationId);
+
+            if (balance <= 0)
+            {
+                var transactions = await transactionRepository.GetTransactions(notificationId);
+                transactions = transactions.Where(t => t.Credit > 0).OrderByDescending(t => t.Date).ToList();
+
+                foreach (var tran in transactions)
+                {
+                    balance += tran.Credit.GetValueOrDefault() - tran.Debit.GetValueOrDefault();
+
+                    if (balance > 0)
+                    {
+                        return tran;
+                    }
+                }
+            }
+            return null;
+        }
+
         public async Task<decimal> RefundLimit(Guid notificationId)
         {
             var transactions = await transactionRepository.GetTransactions(notificationId);


### PR DESCRIPTION
- Retrieve the correct payment received date to be used on the Key Dates Screen.
- Currently retrieving the latest payment date only.
- Only affects Export Notifications.