### PR TITLE
EXTERNAL - Access level for a shared notification

### DIFF
--- a/src/EA.Iws.DataAccess.Tests.Integration/DatabaseDataDeleter.cs
+++ b/src/EA.Iws.DataAccess.Tests.Integration/DatabaseDataDeleter.cs
@@ -116,6 +116,12 @@
         DELETE FROM [Notification].[AnnexCollection] 
         WHERE NotificationId = @NotificationId;
 
+        DELETE FROM [Notification].[SharedUserHistory]
+        WHERE NotificationId = @NotificationId;
+
+        DELETE FROM [Notification].[SharedUser]
+        WHERE NotificationId = @NotificationId;
+
         DELETE FROM [Notification].[Notification] 
         WHERE Id = @NotificationId;
 

--- a/src/EA.Iws.DataAccess.Tests.Integration/EA.Iws.DataAccess.Tests.Integration.csproj
+++ b/src/EA.Iws.DataAccess.Tests.Integration/EA.Iws.DataAccess.Tests.Integration.csproj
@@ -89,6 +89,7 @@
     <Compile Include="SharedUser\IwsContextTests.cs" />
     <Compile Include="SharedUser\NotificationApplicationAuthorizationTests.cs" />
     <Compile Include="SharedUser\NotificationApplicationRepositoryTests.cs" />
+    <Compile Include="SharedUser\SharedUserRepositoryTests.cs" />
     <Compile Include="TransportRouteIntegration.cs" />
     <Compile Include="UnitedKingdomCompetentAuthorityIntegration.cs" />
   </ItemGroup>

--- a/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/IwsContextTests.cs
+++ b/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/IwsContextTests.cs
@@ -32,7 +32,7 @@
         }
 
         [Fact]
-        public async Task CheckExternalUserAccessThrowsException()
+        public async Task RandomExternalUserAccessThrowsException()
         {
             var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
                 UKCompetentAuthority.England, 20181);
@@ -75,7 +75,7 @@
         }
 
         [Fact]
-        public async Task CheckExternalUserAccessDoesNotThrowException()
+        public async Task SharedUserAccessDoesNotThrowException()
         {
             var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
                 UKCompetentAuthority.England, 20181);
@@ -101,6 +101,98 @@
 
             // Set the shared user to be the user context.
             A.CallTo(() => userContext.UserId).Returns(Guid.Parse(sharedUser.UserId));
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // There's no assertion for 'does not throw exception' so just executing it as normal.
+            await authorization.EnsureAccessAsync(notification.Id);
+
+            context.DeleteOnCommit(internalUser);
+            context.DeleteOnCommit(sharedUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
+            context.Entry(aspnetSharedUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task InternalUserAccessDoesNotThrowException()
+        {
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "internal123@mail.com");
+            var aspnetSharedUser = UserFactory.Create(Guid.NewGuid(), "External", "Shared", "12345",
+                "external123@external.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.Users.Add(aspnetSharedUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.England,
+                localArea.Id);
+            var sharedUser = new SharedUser(notification.Id, aspnetSharedUser.Id, DateTimeOffset.Now);
+
+            context.InternalUsers.Add(internalUser);
+            context.SharedUser.Add(sharedUser);
+            await context.SaveChangesAsync();
+
+            // Set the INTERNAL user to be the user context.
+            A.CallTo(() => userContext.UserId).Returns(Guid.Parse(internalUser.UserId));
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // There's no assertion for 'does not throw exception' so just executing it as normal.
+            await authorization.EnsureAccessAsync(notification.Id);
+
+            context.DeleteOnCommit(internalUser);
+            context.DeleteOnCommit(sharedUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
+            context.Entry(aspnetSharedUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task NotificationOwnerAccessDoesNotThrowException()
+        {
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "internal123@mail.com");
+            var aspnetSharedUser = UserFactory.Create(Guid.NewGuid(), "External", "Shared", "12345",
+                "external123@external.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.Users.Add(aspnetSharedUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.England,
+                localArea.Id);
+            var sharedUser = new SharedUser(notification.Id, aspnetSharedUser.Id, DateTimeOffset.Now);
+
+            context.InternalUsers.Add(internalUser);
+            context.SharedUser.Add(sharedUser);
+            await context.SaveChangesAsync();
+
+            // Set the Notification owner to be the user context.
+            A.CallTo(() => userContext.UserId).Returns(notification.UserId);
 
             var authorization = new NotificationApplicationAuthorization(context, userContext);
 

--- a/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/NotificationApplicationAuthorizationTests.cs
+++ b/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/NotificationApplicationAuthorizationTests.cs
@@ -33,14 +33,97 @@
         }
 
         [Fact]
-        public async Task CheckExternalUserAccessThrowsException()
+        public async Task InternalUserSameCompetentAuthorityAccess()
         {
+            // Setup.   
             var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
                 UKCompetentAuthority.England, 20181);
             var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
-                "abc123@mail.com");
+                "abc1111@mail.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.England,
+                localArea.Id);
+
+            context.InternalUsers.Add(internalUser);
+            await context.SaveChangesAsync();
+
+            A.CallTo(() => userContext.UserId).Returns(Guid.Parse(internalUser.UserId));
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // Assert.
+            // There's no assertion for 'does not throw exception' so just executing it as normal.
+            await authorization.EnsureAccessAsync(notification.Id);
+
+            // Clear data.
+            context.DeleteOnCommit(internalUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task InternalUserDifferentCompetentAuthorityAccessThrowsException()
+        {
+            // Setup.   
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "abc321@mail.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            // Internal user is different UKCA from the notification - should cause the exception.
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.Wales,
+                localArea.Id);
+
+            context.InternalUsers.Add(internalUser);
+            await context.SaveChangesAsync();
+
+            A.CallTo(() => userContext.UserId).Returns(Guid.Parse(internalUser.UserId));
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // Assert.
+            await Assert.ThrowsAsync<SecurityException>(() => authorization.EnsureAccessAsync(notification.Id));
+
+            // Clear data.
+            context.DeleteOnCommit(internalUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task RandomExternalUserAccessThrowsException()
+        {
+            // Setup.
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "12345678@mail.com");
             var aspnetSharedUser = UserFactory.Create(Guid.NewGuid(), "External", "Shared", "12345",
-                "123456@external.com");
+                "test123456@external.com");
             var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
 
             context.NotificationApplications.Add(notification);
@@ -62,8 +145,10 @@
 
             var authorization = new NotificationApplicationAuthorization(context, userContext);
 
+            // Assert.
             await Assert.ThrowsAsync<SecurityException>(() => authorization.EnsureAccessAsync(notification.Id));
 
+            // Clear data.
             context.DeleteOnCommit(internalUser);
             context.DeleteOnCommit(sharedUser);
             await context.SaveChangesAsync();
@@ -78,8 +163,9 @@
         }
 
         [Fact]
-        public async Task CheckExternalUserAccessDoesNotThrowException()
+        public async Task SharedUserNotificationAccess()
         {
+            // Setup.
             var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
                 UKCompetentAuthority.England, 20181);
             var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
@@ -107,15 +193,97 @@
 
             var authorization = new NotificationApplicationAuthorization(context, userContext);
 
+            // Assert.
             // There's no assertion for 'does not throw exception' so just executing it as normal.
             await authorization.EnsureAccessAsync(notification.Id);
 
+            // Clear data.
             context.DeleteOnCommit(internalUser);
             context.DeleteOnCommit(sharedUser);
             await context.SaveChangesAsync();
 
             context.Entry(aspnetInternalUser).State = EntityState.Deleted;
             context.Entry(aspnetSharedUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task CheckExternalUserNotOwnerAccessThrowsException()
+        {
+            // Setup.
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "eddiejones@mail.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.England,
+                localArea.Id);
+
+            context.InternalUsers.Add(internalUser);
+            await context.SaveChangesAsync();
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // Assert.
+            await Assert.ThrowsAsync<SecurityException>(() => authorization.EnsureAccessIsOwnerAsync(notification.Id));
+
+            // Clear data.
+            context.DeleteOnCommit(internalUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
+            context.Entry(localArea).State = EntityState.Deleted;
+            await context.SaveChangesAsync();
+
+            context.DeleteOnCommit(notification);
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task CheckNotificationOwnerAccessDoesNotThrowException()
+        {
+            // Setup.
+            var notification = NotificationApplicationFactory.Create(Guid.NewGuid(), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20181);
+            var aspnetInternalUser = UserFactory.Create(Guid.NewGuid(), "Internal", "Internal Last", "12345",
+                "internal1234@mail.com");
+            var localArea = new LocalArea(Guid.NewGuid(), "Test Area", (int)UKCompetentAuthority.England);
+
+            context.NotificationApplications.Add(notification);
+            context.Users.Add(aspnetInternalUser);
+            context.LocalAreas.Add(localArea);
+            await context.SaveChangesAsync();
+
+            var internalUser = new InternalUser(aspnetInternalUser.Id, "test", UKCompetentAuthority.England,
+                localArea.Id);
+
+            context.InternalUsers.Add(internalUser);
+            await context.SaveChangesAsync();
+
+            // Set the shared user to be the user context.
+            A.CallTo(() => userContext.UserId).Returns(notification.UserId);
+
+            var authorization = new NotificationApplicationAuthorization(context, userContext);
+
+            // Assert.
+            // There's no assertion for 'does not throw exception' so just executing it as normal.
+            await authorization.EnsureAccessAsync(notification.Id);
+
+            // Clear data.
+            context.DeleteOnCommit(internalUser);
+            await context.SaveChangesAsync();
+
+            context.Entry(aspnetInternalUser).State = EntityState.Deleted;
             context.Entry(localArea).State = EntityState.Deleted;
             await context.SaveChangesAsync();
 

--- a/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/SharedUserRepositoryTests.cs
+++ b/src/EA.Iws.DataAccess.Tests.Integration/SharedUser/SharedUserRepositoryTests.cs
@@ -1,0 +1,128 @@
+﻿namespace EA.Iws.DataAccess.Tests.Integration.SharedUser
+{
+    using System;
+    using System.Data.Entity;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Core.Notification;
+    using Core.Shared;
+    using Domain;
+    using Domain.NotificationApplication;
+    using Domain.Security;
+    using FakeItEasy;
+    using Prsd.Core.Domain;
+    using Repositories;
+    using TestHelpers.Helpers;
+    using Xunit;
+    using NotificationApplicationFactory = TestHelpers.Helpers.NotificationApplicationFactory;
+
+    public class SharedUserRepositoryTests : IDisposable
+    {
+        private readonly IwsContext context;
+        private readonly INotificationApplicationAuthorization authorization;
+        private readonly SharedUserRepository repository;
+
+        private readonly Guid[] preRunNotifications;
+        private readonly User ownerUser;
+        private readonly User sharedUser;
+        private readonly NotificationApplication notification;
+
+        public SharedUserRepositoryTests()
+        {
+            ownerUser = UserFactory.Create(Guid.NewGuid(), "Owner", "User", "12345",
+                "owneruser111@mail.com");
+            sharedUser = UserFactory.Create(Guid.NewGuid(), "Shared", "User", "12345",
+                "shareduser111@external.com");
+
+            var userContext = A.Fake<IUserContext>();
+
+            A.CallTo(() => userContext.UserId).Returns(Guid.Parse(ownerUser.Id));
+
+            context = new IwsContext(userContext, A.Fake<IEventDispatcher>());
+            authorization = A.Fake<INotificationApplicationAuthorization>();
+            repository = new SharedUserRepository(context, authorization);
+
+            preRunNotifications = context.NotificationApplications.Select(na => na.Id).ToArray();
+
+            notification = NotificationApplicationFactory.Create(Guid.Parse(ownerUser.Id), NotificationType.Recovery,
+                UKCompetentAuthority.England, 20191);
+
+            context.Users.Add(ownerUser);
+            context.Users.Add(sharedUser);
+            context.NotificationApplications.Add(notification);
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task AddSharedUserChecksAuthorization()
+        {
+            var shared = new SharedUser(notification.Id, sharedUser.Id, DateTimeOffset.Now);
+
+            await repository.AddSharedUser(shared);
+
+            A.CallTo(() => authorization.EnsureAccessIsOwnerAsync(shared.NotificationId)).MustHaveHappened();
+
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task RemoveSharedUserChecksAuthorization()
+        {
+            var shared = new SharedUser(notification.Id, sharedUser.Id, DateTimeOffset.Now);
+
+            context.SharedUser.Add(shared);
+            await context.SaveChangesAsync();
+
+            await repository.RemoveSharedUser(notification.Id, shared.Id);
+
+            A.CallTo(() => authorization.EnsureAccessIsOwnerAsync(shared.NotificationId)).MustHaveHappened();
+
+            await context.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task GetAllSharedUsersChecksAuthorization()
+        {
+            var shared = new SharedUser(notification.Id, sharedUser.Id, DateTimeOffset.Now);
+
+            context.SharedUser.Add(shared);
+            await context.SaveChangesAsync();
+
+            await repository.GetAllSharedUsers(notification.Id);
+
+            A.CallTo(() => authorization.EnsureAccessAsync(notification.Id)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task GetSharedUserByIdChecksAuthorization()
+        {
+            var shared = new SharedUser(notification.Id, sharedUser.Id, DateTimeOffset.Now);
+
+            context.SharedUser.Add(shared);
+            await context.SaveChangesAsync();
+
+            await repository.GetSharedUserById(notification.Id, shared.Id);
+
+            A.CallTo(() => authorization.EnsureAccessAsync(notification.Id)).MustHaveHappened();
+        }
+
+        public void Dispose()
+        {
+            var createdNotifications =
+                context.NotificationApplications.Where(n => !preRunNotifications.Contains(n.Id))
+                    .Select(n => n.Id)
+                    .ToArray();
+
+            foreach (var createdNotification in createdNotifications)
+            {
+                DatabaseDataDeleter.DeleteDataForNotification(createdNotification, context);
+            }
+
+            context.Entry(ownerUser).State = EntityState.Deleted;
+            context.Entry(sharedUser).State = EntityState.Deleted;
+            context.SaveChanges();
+
+            context.Dispose();
+        }
+    }
+}

--- a/src/EA.Iws.DataAccess/Repositories/SharedUserRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/SharedUserRepository.cs
@@ -6,46 +6,47 @@
     using System.Data.Entity;
     using System.Linq;
     using System.Threading.Tasks;
+    using Domain.Security;
 
     public class SharedUserRepository : ISharedUserRepository
     {
         private readonly IwsContext context;
+        private readonly INotificationApplicationAuthorization authorization;
 
-        public SharedUserRepository(IwsContext context)
+        public SharedUserRepository(IwsContext context, INotificationApplicationAuthorization authorization)
         {
             this.context = context;
+            this.authorization = authorization;
         }
 
-        public void AddSharedUser(SharedUser sharedUser)
+        public async Task AddSharedUser(SharedUser sharedUser)
         {
-            this.context.SharedUser.Add(sharedUser);
+            await authorization.EnsureAccessIsOwnerAsync(sharedUser.NotificationId);
+
+            context.SharedUser.Add(sharedUser);
         }
 
         public async Task RemoveSharedUser(Guid notificationId, Guid sharedId)
         {
-             var sharedUser = await context.SharedUser.Where(x => x.NotificationId == notificationId && x.Id == sharedId).SingleAsync();
+            await authorization.EnsureAccessIsOwnerAsync(notificationId);
+
+            var sharedUser = await context.SharedUser.Where(x => x.NotificationId == notificationId && x.Id == sharedId).SingleAsync();
 
             context.DeleteOnCommit(sharedUser);
         }
 
         public async Task<IEnumerable<SharedUser>> GetAllSharedUsers(Guid notificationId)
         {
+            await authorization.EnsureAccessAsync(notificationId);
+
             return await context.SharedUser.Where(x => x.NotificationId == notificationId).ToArrayAsync();
         }
 
         public async Task<SharedUser> GetSharedUserById(Guid notificationId, Guid sharedId)
         {
+            await authorization.EnsureAccessAsync(notificationId);
+
             return await context.SharedUser.Where(x => x.NotificationId == notificationId && x.Id == sharedId).SingleAsync();
-        }
-
-        public async Task<int> GetSharedUserCount(Guid notificationId)
-        {
-            var totalMovements = await context.SharedUser
-                  .Where(m =>
-                      m.NotificationId == notificationId)
-                  .CountAsync();
-
-            return totalMovements;
         }
     }
 }

--- a/src/EA.Iws.DataAccess/Security/NotificationApplicationAuthorization.cs
+++ b/src/EA.Iws.DataAccess/Security/NotificationApplicationAuthorization.cs
@@ -34,6 +34,24 @@
             }
         }
 
+        public async Task EnsureAccessIsOwnerAsync(Guid notificationId)
+        {
+            var notification = await context.NotificationApplications.Where(n => n.Id == notificationId).SingleAsync();
+
+            if (await IsInternal())
+            {
+                await CheckCompetentAuthority(notification);
+            }
+            else
+            {
+                if (notification.UserId != userContext.UserId)
+                {
+                    throw new SecurityException(string.Format("Access denied to this notification {0} for user {1}",
+                        notificationId, userContext.UserId));
+                }
+            }
+        }
+
         private async Task CheckCompetentAuthority(NotificationApplication notification)
         {
             var userCompetentAuthority = await context.GetUsersCompetentAuthority(userContext);

--- a/src/EA.Iws.Domain/NotificationApplication/ISharedUserRepository.cs
+++ b/src/EA.Iws.Domain/NotificationApplication/ISharedUserRepository.cs
@@ -5,12 +5,12 @@
     using System.Threading.Tasks;
     public interface ISharedUserRepository
     {
-        void AddSharedUser(SharedUser sharedUser);
+        Task AddSharedUser(SharedUser sharedUser);
+
         Task RemoveSharedUser(Guid notificationId, Guid sharedId);
+
         Task<IEnumerable<SharedUser>> GetAllSharedUsers(Guid notificationId);
 
         Task<SharedUser> GetSharedUserById(Guid notificationId, Guid sharedId);
-
-        Task<int> GetSharedUserCount(Guid notificationId);
     }
 }

--- a/src/EA.Iws.Domain/Security/INotificationApplicationAuthorization.cs
+++ b/src/EA.Iws.Domain/Security/INotificationApplicationAuthorization.cs
@@ -6,5 +6,7 @@
     public interface INotificationApplicationAuthorization
     {
         Task EnsureAccessAsync(Guid notificationId);
+
+        Task EnsureAccessIsOwnerAsync(Guid notificationId);
     }
 }

--- a/src/EA.Iws.RequestHandlers/Notification/CheckIfNotificationOwnerHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Notification/CheckIfNotificationOwnerHandler.cs
@@ -22,11 +22,7 @@
         {
             var notificationOwner = (await context.NotificationApplications.SingleAsync(n => n.Id == message.NotificationId)).UserId;
 
-            if (notificationOwner.CompareTo(userContext.UserId) == 0)
-            {
-                return true;
-            }
-            return false;
+            return notificationOwner.CompareTo(userContext.UserId) == 0;
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers/Notification/SharedUserAdded.cs
+++ b/src/EA.Iws.RequestHandlers/Notification/SharedUserAdded.cs
@@ -24,7 +24,7 @@
                 @event.UserId,
                 SystemTime.UtcNow);
 
-            repository.AddSharedUser(sharedUser);
+            await repository.AddSharedUser(sharedUser);
 
             await context.SaveChangesAsync();
         }

--- a/src/EA.Iws.RequestHandlers/SharedUsers/CheckIfSharedUserExistsHandler.cs
+++ b/src/EA.Iws.RequestHandlers/SharedUsers/CheckIfSharedUserExistsHandler.cs
@@ -1,12 +1,11 @@
 ﻿namespace EA.Iws.RequestHandlers.SharedUsers
 {
-    using DataAccess;
+    using System.Linq;
     using Domain.NotificationApplication;
-    using Prsd.Core.Domain;
     using Prsd.Core.Mediator;
-    using Requests.Notification;
     using Requests.SharedUsers;
     using System.Threading.Tasks;
+
     internal class CheckIfSharedUserExistsHandler : IRequestHandler<CheckIfSharedUserExists, bool>
     {
         private readonly ISharedUserRepository repository;
@@ -17,13 +16,9 @@
         }
         public async Task<bool> HandleAsync(CheckIfSharedUserExists message)
         {
-            var totalCount = await repository.GetSharedUserCount(message.NotificationId);
+            var sharedUsers = await repository.GetAllSharedUsers(message.NotificationId);
 
-            if (totalCount > 0)
-            {
-                return true;
-            }
-            return false;
+            return sharedUsers.Any();
         }
     }
 }

--- a/src/EA.Iws.Requests/Notification/CheckIfNotificationOwner.cs
+++ b/src/EA.Iws.Requests/Notification/CheckIfNotificationOwner.cs
@@ -4,8 +4,9 @@
     using Core.Authorization.Permissions;
     using Prsd.Core.Mediator;
     using System;
+
     [RequestAuthorization(ExportNotificationPermissions.CanReadExportNotification)]
-   public class CheckIfNotificationOwner : IRequest<bool>
+    public class CheckIfNotificationOwner : IRequest<bool>
     {
         public Guid NotificationId { get; private set; }
 

--- a/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationApplication/SharedUser/NotificationOwnerFilterControllerAttributeTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationApplication/SharedUser/NotificationOwnerFilterControllerAttributeTests.cs
@@ -1,0 +1,38 @@
+﻿namespace EA.Iws.Web.Tests.Unit.Controllers.NotificationApplication.SharedUser
+{
+    using System.Linq;
+    using Areas.NotificationApplication.Controllers;
+    using Web.Controllers;
+    using Web.Infrastructure;
+    using Xunit;
+
+    public class NotificationOwnerFilterControllerAttributeTests
+    {
+        [Fact]
+        public void ChangeNotificationOwnerControllerHasNotificationOwnerFilter()
+        {
+            var attributes = typeof(ChangeNotificationOwnerController).GetCustomAttributes(
+                typeof(NotificationOwnerFilter), true);
+
+            Assert.True(attributes.Any());
+        }
+
+        [Fact]
+        public void ShareNotificationControllerHasNotificationOwnerFilter()
+        {
+            var attributes = typeof(ShareNotificationController).GetCustomAttributes(
+                typeof(NotificationOwnerFilter), true);
+
+            Assert.True(attributes.Any());
+        }
+
+        [Fact]
+        public void ReviewUserAccessControllerHasNotificationOwnerFilter()
+        {
+            var attributes = typeof(ReviewUserAccessController).GetCustomAttributes(
+                typeof(NotificationOwnerFilter), true);
+
+            Assert.True(attributes.Any());
+        }
+    }
+}

--- a/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
+++ b/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Controllers\ImportNotification\WasteOperationControllerTests.cs" />
     <Compile Include="Controllers\NotificationApplication\ReviewUserAccessControllerTests.cs" />
     <Compile Include="Controllers\NotificationApplication\AddSharedUserForNotificationControllerTests.cs" />
+    <Compile Include="Controllers\NotificationApplication\SharedUser\NotificationOwnerFilterControllerAttributeTests.cs" />
     <Compile Include="Controllers\NotificationAssessment\DecisionControllerTests.cs" />
     <Compile Include="Controllers\NotificationMovements\CancelMovementControllerTests.cs" />
     <Compile Include="Controllers\NotificationApplication\BaseWasteCodeControllerTests.cs" />
@@ -180,6 +181,7 @@
     <Compile Include="Controllers\NotificationApplication\WasteOperationsControllerTests.cs" />
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Infrastructure\HtmlHelperExtensionsTests.cs" />
+    <Compile Include="Infrastructure\NotificationOwnerFilterTests.cs" />
     <Compile Include="Infrastructure\RangeExtensionsTests.cs" />
     <Compile Include="Infrastructure\Validation\CompetentAuthorityEmailAddressAttributeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/EA.Iws.Web.Tests.Unit/Infrastructure/NotificationOwnerFilterTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/Infrastructure/NotificationOwnerFilterTests.cs
@@ -1,0 +1,99 @@
+﻿namespace EA.Iws.Web.Tests.Unit.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Web;
+    using System.Web.Mvc;
+    using System.Web.Routing;
+    using FakeItEasy;
+    using Prsd.Core.Mediator;
+    using Requests.Notification;
+    using Web.Infrastructure;
+    using Xunit;
+
+    public class NotificationOwnerFilterTests
+    {
+        private readonly NotificationOwnerFilter filter;
+        private readonly IMediator mediator;
+        private readonly ActionExecutingContext actionExecutingContext;
+        private readonly Controller controller;
+
+        public NotificationOwnerFilterTests()
+        {
+            mediator = A.Fake<IMediator>();
+            A.CallTo(
+                () =>
+                    mediator.SendAsync(A<CheckIfNotificationOwner>.Ignored))
+                .Returns(true);
+
+            var request = A.Fake<HttpRequestBase>();
+            var context = A.Fake<HttpContextBase>();
+
+            A.CallTo(() => request.Url).Returns(new Uri("https://test.com"));
+            A.CallTo(() => request.UrlReferrer).Returns(new Uri("https://test.com"));
+            A.CallTo(() => context.Request).Returns(request);
+            
+            var dictionaryValueProv = new DictionaryValueProvider<object>(
+            new Dictionary<string, object>() { { "id", Guid.NewGuid() } }, null);
+
+            controller = A.Fake<Controller>();
+            controller.ControllerContext = new ControllerContext(context, new RouteData(), controller);
+            controller.ValueProvider = dictionaryValueProv;
+
+            actionExecutingContext = new ActionExecutingContext
+            {
+                Controller = controller,
+                Result = new HttpStatusCodeResult(HttpStatusCode.OK)
+            };
+
+            filter = new NotificationOwnerFilter { Mediator = mediator };
+        }
+
+        [Fact]
+        public void CheckIfNotificationOwner()
+        {
+            A.CallTo(
+                    () =>
+                            mediator.SendAsync(A<CheckIfNotificationOwner>.Ignored))
+                .Returns(true);
+
+            filter.OnActionExecuting(actionExecutingContext);
+
+            var result = (HttpStatusCodeResult)actionExecutingContext.Result;
+
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public void NotOwnerReturnsForbidden()
+        {
+            A.CallTo(
+                    () =>
+                            mediator.SendAsync(A<CheckIfNotificationOwner>.Ignored))
+                .Returns(false);
+
+            filter.OnActionExecuting(actionExecutingContext);
+
+            var result = (HttpStatusCodeResult)actionExecutingContext.Result;
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+        }
+
+        [Fact]
+        public void MissingNotificationIdReturnsNotFound()
+        {
+            // Set a new value provider containing an non GUID value so that parsing fails.
+            var newDictionaryValueProv = new DictionaryValueProvider<object>(
+                new Dictionary<string, object>() { { "id", new { } } }, null);
+
+            controller.ValueProvider = newDictionaryValueProv;
+
+            filter.OnActionExecuting(actionExecutingContext);
+
+            var result = (HttpStatusCodeResult)actionExecutingContext.Result;
+
+            Assert.Equal((int)HttpStatusCode.NotFound, result.StatusCode);
+        }
+    }
+}

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ReviewUserAccessController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ReviewUserAccessController.cs
@@ -10,9 +10,11 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using System.Web.Mvc;
+    using Infrastructure;
     using ViewModels.ReviewUserAccess;
 
     [Authorize]
+    [NotificationOwnerFilter]
     public class ReviewUserAccessController : Controller
     {
       private readonly IMediator mediator;

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ShareNotificationController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ShareNotificationController.cs
@@ -15,6 +15,7 @@
     using ViewModels.ShareNotification;
 
     [AuthorizeActivity(typeof(AddSharedUser))]
+    [NotificationOwnerFilter]
     public class ShareNotificationController : Controller
     {
         private readonly IMediator mediator;

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Views/Options/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Views/Options/Index.cshtml
@@ -77,11 +77,11 @@
                     {
                         @Html.ActionLink(Resource.AssignNotification, "Index", "ChangeNotificationOwner", new { id = Model.NotificationId, area = string.Empty }, null)
                         @Html.ActionLink(Resource.ShareNotification, "ShareNotification", "ShareNotification", new { id = Model.NotificationId, area = "NotificationApplication" }, null)
-                    }
 
-                    @if (Model.HasSharedUsers)
-                    {
-                        @Html.ActionLink(Resource.ReviewAccess, "UserList", "ReviewUserAccess", new { id = Model.NotificationId, area = "NotificationApplication" }, null)
+                        if (Model.HasSharedUsers)
+                        {
+                            @Html.ActionLink(Resource.ReviewAccess, "UserList", "ReviewUserAccess", new { id = Model.NotificationId, area = "NotificationApplication" }, null)
+                        }
                     }
 
                     @if (Model.NotificationStatus == NotificationStatus.NotSubmitted)

--- a/src/EA.Iws.Web/Controllers/ChangeNotificationOwnerController.cs
+++ b/src/EA.Iws.Web/Controllers/ChangeNotificationOwnerController.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using System.Web.Mvc;
+    using Infrastructure;
     using Infrastructure.Authorization;
     using Prsd.Core.Mediator;
     using Requests.Notification;
@@ -10,6 +11,7 @@
     using ViewModels.ChangeNotificationOwner;
 
     [AuthorizeActivity(typeof(ChangeUser))]
+    [NotificationOwnerFilter]
     public class ChangeNotificationOwnerController : Controller
     {
         private readonly IMediator mediator;

--- a/src/EA.Iws.Web/EA.Iws.Web.csproj
+++ b/src/EA.Iws.Web/EA.Iws.Web.csproj
@@ -2256,6 +2256,7 @@
       <DependentUpon>WhatNextResources.resx</DependentUpon>
     </Compile>
     <Compile Include="Areas\NotificationApplication\Controllers\ShareNotificationController.cs" />
+    <Compile Include="Infrastructure\NotificationOwnerFilter.cs" />
     <Compile Include="Infrastructure\Validation\NotificationShareUserValidationAttribute.cs" />
     <Compile Include="ViewModels\ChangeNotificationOwner\ChangeOwnerViewModel.cs" />
     <Compile Include="ViewModels\ChangeNotificationOwner\ConfirmViewModel.cs" />

--- a/src/EA.Iws.Web/Infrastructure/NotificationOwnerFilter.cs
+++ b/src/EA.Iws.Web/Infrastructure/NotificationOwnerFilter.cs
@@ -1,0 +1,32 @@
+﻿namespace EA.Iws.Web.Infrastructure
+{
+    using System;
+    using System.Net;
+    using System.Web.Mvc;
+    using Prsd.Core.Mediator;
+    using Requests.Notification;
+
+    public class NotificationOwnerFilter : ActionFilterAttribute
+    {
+        public IMediator Mediator { get; set; }
+
+        public override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            Guid notificationId;
+            if (Guid.TryParse(filterContext.Controller.ValueProvider.GetValue("id").AttemptedValue,
+                out notificationId))
+            {
+                var isOwner = Mediator.SendAsync(new CheckIfNotificationOwner(notificationId)).Result;
+
+                if (!isOwner)
+                {
+                    filterContext.Result = new HttpStatusCodeResult(HttpStatusCode.Forbidden);
+                }
+            }
+            else
+            {
+                filterContext.Result = new HttpNotFoundResult();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The check for access level has already been done in a previous task. These are done in:

- `EA.Iws.DataAccess.Security.NotificationApplicationAuthorization`
- `EA.Iws.DataAccess.IwsContext`

Main changes in this PR are the unit tests. Especially around access to the Shared User infrastructure.
