### PR TITLE
Consented record error

### DIFF
--- a/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationMovements/CreateControllerTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationMovements/CreateControllerTests.cs
@@ -1,0 +1,79 @@
+﻿namespace EA.Iws.Web.Tests.Unit.Controllers.NotificationMovements
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Web.Mvc;
+    using Areas.NotificationMovements.Controllers;
+    using Core.Movement;
+    using Core.PackagingType;
+    using Core.Rules;
+    using Core.Shared;
+    using FakeItEasy;
+    using Prsd.Core.Mediator;
+    using Requests.NotificationMovements;
+    using Requests.NotificationMovements.Create;
+    using Xunit;
+
+    public class CreateControllerTests
+    {
+        private readonly IMediator mediator;
+        private readonly CreateController controller;
+        private readonly MovementRulesSummary movementRulesSummary;
+
+        public CreateControllerTests()
+        {
+            mediator = A.Fake<IMediator>();
+            controller = new CreateController(mediator);
+            movementRulesSummary = new MovementRulesSummary(new List<RuleResult<MovementRules>>());
+
+            A.CallTo(() => mediator.SendAsync(A<GetMovementRulesSummary>.Ignored)).Returns(movementRulesSummary);
+            A.CallTo(() => mediator.SendAsync(A<GetShipmentInfo>.Ignored)).Returns(GetShipmentInfo());
+        }
+
+        [Fact]
+        public async Task Index_Send_Request()
+        {
+            var result = await controller.Index(Guid.NewGuid()) as ViewResult;
+
+            A.CallTo(() => mediator.SendAsync(A<GetMovementRulesSummary>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+
+            A.CallTo(() => mediator.SendAsync(A<GetShipmentInfo>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+
+            Assert.NotNull(result);
+            Assert.True(result.ViewName == "Index");
+        }
+
+        [Fact]
+        public async Task RedirectToShipmentDate_Send_Request()
+        {
+            var result = await controller.RedirectToShipmentDate(Guid.NewGuid()) as ViewResult;
+
+            // Redirect from warning page if Consent expires in 4 working days or less than 3 days
+            // should skip the rules.
+            A.CallTo(() => mediator.SendAsync(A<GetMovementRulesSummary>.Ignored))
+                .MustHaveHappened(Repeated.Never);
+
+            A.CallTo(() => mediator.SendAsync(A<GetShipmentInfo>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+
+            Assert.NotNull(result);
+            Assert.True(result.ViewName == "Index");
+        }
+
+        private static ShipmentInfo GetShipmentInfo()
+        {
+            var shipmentDates = new ShipmentDates() { StartDate = DateTime.Now, EndDate = DateTime.Now.AddMonths(6) };
+            var packagingData = new PackagingData() { OtherDescription = "Packaging description" };
+
+            return new ShipmentInfo()
+            {
+                ShipmentDates = shipmentDates,
+                PackagingData = packagingData,
+                ShipmentQuantityUnits = ShipmentQuantityUnits.Tonnes
+            };
+        }
+    }
+}

--- a/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
+++ b/src/EA.Iws.Web.Tests.Unit/EA.Iws.Web.Tests.Unit.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Controllers\NotificationApplication\StateOfImportControllerTests.cs" />
     <Compile Include="Controllers\NotificationApplication\TransitStateControllerTests.cs" />
     <Compile Include="Controllers\NotificationApplication\WasteOperationsControllerTests.cs" />
+    <Compile Include="Controllers\NotificationMovements\CreateControllerTests.cs" />
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Infrastructure\HtmlHelperExtensionsTests.cs" />
     <Compile Include="Infrastructure\NotificationOwnerFilterTests.cs" />

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/CreateController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/CreateController.cs
@@ -32,29 +32,7 @@
         [HttpGet]
         public async Task<ActionResult> Index(Guid notificationId)
         {
-            ViewBag.NotificationId = notificationId;
-
-            var ruleSummary = await mediator.SendAsync(new GetMovementRulesSummary(notificationId));
-
-            if (!ruleSummary.IsSuccess)
-            {
-                return GetRuleErrorView(ruleSummary);
-            }
-
-            var shipmentInfo = await mediator.SendAsync(new GetShipmentInfo(notificationId));
-
-            var model = new CreateMovementsViewModel(shipmentInfo);
-
-            if (TempData["TempMovement"] != null)
-            {
-                var tempMovement = (TempMovement)TempData["TempMovement"];
-                model.NumberToCreate = tempMovement.NumberToCreate;
-                model.Quantity = tempMovement.Quantity.ToString();
-                model.Units = tempMovement.ShipmentQuantityUnits;
-                model.PackagingTypes.SetSelectedValues(tempMovement.PackagingTypes);                      
-            }
-
-            return View(model);
+            return await GetIndex(notificationId);
         }
 
         [HttpPost]
@@ -292,6 +270,42 @@
                 await mediator.SendAsync(new GetUnitedKingdomCompetentAuthorityByNotificationId(notificationId));
 
             return View(competentAuthority.AsUKCompetantAuthority());
+        }
+
+        [HttpGet]
+        public async Task<ActionResult> RedirectToShipmentDate(Guid notificationId)
+        {
+            return await GetIndex(notificationId, true);
+        }
+
+        private async Task<ActionResult> GetIndex(Guid notificationId, bool skipRules = false)
+        {
+            ViewBag.NotificationId = notificationId;
+
+            if (!skipRules)
+            {
+                var ruleSummary = await mediator.SendAsync(new GetMovementRulesSummary(notificationId));
+
+                if (!ruleSummary.IsSuccess)
+                {
+                    return GetRuleErrorView(ruleSummary);
+                }
+            }
+
+            var shipmentInfo = await mediator.SendAsync(new GetShipmentInfo(notificationId));
+
+            var model = new CreateMovementsViewModel(shipmentInfo);
+
+            if (TempData["TempMovement"] != null)
+            {
+                var tempMovement = (TempMovement)TempData["TempMovement"];
+                model.NumberToCreate = tempMovement.NumberToCreate;
+                model.Quantity = tempMovement.Quantity.ToString();
+                model.Units = tempMovement.ShipmentQuantityUnits;
+                model.PackagingTypes.SetSelectedValues(tempMovement.PackagingTypes);
+            }
+
+            return View("Index", model);
         }
 
         [Serializable]


### PR DESCRIPTION
There was a missing controller action that was still being used by a link (Continue button). Looking through the history, seems to have been removed over a year ago now so this bug has existed for a while. 

Added new unit test for the controller.

`RedirectToShipmentDate` is being used in the the views `ConsentExpiresInFourWorkingDays` and `ConsentExpiresInThreeOrLessWorkingDays` but the `RedirectToShipmentDate` was deleted by mistake around 2016.