### PR TITLE
Waste codes order - H and HP

### DIFF
--- a/src/EA.Iws.RequestHandlers/Mappings/WasteCodeMap.cs
+++ b/src/EA.Iws.RequestHandlers/Mappings/WasteCodeMap.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using Core.WasteCodes;
     using Domain.NotificationApplication;
     using Prsd.Core.Mapper;

--- a/src/EA.Iws.Web.Tests.Unit/ViewModels/ImportNotification/SummaryTableContainerViewModelTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/ViewModels/ImportNotification/SummaryTableContainerViewModelTests.cs
@@ -56,8 +56,8 @@
             var result = model.Details.WasteType.YCodes.WasteCodes;
             var expected = CreateYCodes().OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Name, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             });
 
@@ -72,8 +72,8 @@
             var result = model.Details.WasteType.HCodes.WasteCodes;
             var expected = CreateHCodes().OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Name, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             });
 
@@ -134,7 +134,8 @@
             {
                 new WasteCode() { Name = "Y10", Description = "Metal carbonyls" },
                 new WasteCode() { Name = "Y4", Description = "Copper compounds" },
-                new WasteCode() { Name = "Y1", Description = "Zinc compounds" }
+                new WasteCode() { Name = "Y1.3", Description = "Copper compounds" },
+                new WasteCode() { Name = "Y1.1", Description = "Zinc compounds" }
             };
         }
 
@@ -144,7 +145,8 @@
             {
                 new WasteCode() { Name = "H1", Description = "Explosive" },
                 new WasteCode() { Name = "H10", Description = "Liberation of toxic gases in contact with air or water" },
-                new WasteCode() { Name = "H2", Description = "Ecotoxic" }
+                new WasteCode() { Name = "H2.3", Description = "Ecotoxic" },
+                new WasteCode() { Name = "H2.2", Description = "Ecotoxic" }
             };
         }
 

--- a/src/EA.Iws.Web.Tests.Unit/ViewModels/NotificationApplication/WasteCodeOverviewViewModelTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/ViewModels/NotificationApplication/WasteCodeOverviewViewModelTests.cs
@@ -31,8 +31,8 @@
             var result = model.YCodes;
             var expected = CreateYCodes().OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Code, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
 
@@ -47,8 +47,8 @@
             var result = model.HCodes;
             var expected = CreateHCodes().OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Code, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
 
@@ -124,6 +124,7 @@
             return new[]
             {
                 new WasteCodeData() { Code = "Y11" },
+                new WasteCodeData() { Code = "Y1.4" },
                 new WasteCodeData() { Code = "Y1" },
                 new WasteCodeData() { Code = "Y2" }
             };
@@ -134,6 +135,7 @@
             return new[]
             {
                 new WasteCodeData() { Code = "H12" },
+                new WasteCodeData() { Code = "HP2.2" },
                 new WasteCodeData() { Code = "HP21" },
                 new WasteCodeData() { Code = "H1" },
                 new WasteCodeData() { Code = "HP2" },
@@ -145,7 +147,7 @@
         {
             return new[]
             {
-                new WasteCodeData() { Code = "4.1" },
+                new WasteCodeData() { Code = "4.3" },
                 new WasteCodeData() { Code = "7" },
                 new WasteCodeData() { Code = "2" }
             };

--- a/src/EA.Iws.Web/Areas/ImportNotification/ViewModels/Home/SummaryTableContainerViewModel.cs
+++ b/src/EA.Iws.Web/Areas/ImportNotification/ViewModels/Home/SummaryTableContainerViewModel.cs
@@ -34,14 +34,14 @@
             var ewcCodesOrdered = details.WasteType.EwcCodes.WasteCodes.OrderBy(w => w.Name).ToList();
             var ycodesOrdered = details.WasteType.YCodes.WasteCodes.OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Name, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToList();
             var hcodesOrdered = details.WasteType.HCodes.WasteCodes.OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Name, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToList();
             var unclassesOrdered = details.WasteType.UnClasses.WasteCodes.OrderBy(w => w.Name).ToList();

--- a/src/EA.Iws.Web/Areas/NotificationApplication/ViewModels/NotificationApplication/WasteCodeOverviewViewModel.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/ViewModels/NotificationApplication/WasteCodeOverviewViewModel.cs
@@ -76,14 +76,14 @@
             OtherCodes = classifyYourWasteInfo.OtherCodes;
             YCodes = classifyYourWasteInfo.YCodes.OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Code, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
             HCodes = classifyYourWasteInfo.HCodes.OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
             {
-                int val;
-                int.TryParse(Regex.Match(w.Code, @"(\d+)").Value, out val);
+                double val;
+                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
             UnClass = classifyYourWasteInfo.UnClass.OrderBy(w => w.Code).ToArray();


### PR DESCRIPTION
Follow up fix for #628 and #629 .
H and HP codes can have decimal values so updated the regex to deal with this.