### PR TITLE
Waste codes ordering - add null check

### DIFF
--- a/src/EA.Iws.Web/Areas/ImportNotification/ViewModels/Home/SummaryTableContainerViewModel.cs
+++ b/src/EA.Iws.Web/Areas/ImportNotification/ViewModels/Home/SummaryTableContainerViewModel.cs
@@ -32,16 +32,16 @@
                                            details.Status != ImportNotificationStatus.NotificationReceived;
 
             var ewcCodesOrdered = details.WasteType.EwcCodes.WasteCodes.OrderBy(w => w.Name).ToList();
-            var ycodesOrdered = details.WasteType.YCodes.WasteCodes.OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
+            var ycodesOrdered = details.WasteType.YCodes.WasteCodes.OrderBy(w => Regex.Match(!string.IsNullOrEmpty(w.Name) ? w.Name : string.Empty, @"(\D+)").Value).ThenBy(w =>
             {
                 double val;
-                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
+                double.TryParse(Regex.Match(!string.IsNullOrEmpty(w.Name) ? w.Name : string.Empty, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToList();
-            var hcodesOrdered = details.WasteType.HCodes.WasteCodes.OrderBy(w => Regex.Match(w.Name, @"(\D+)").Value).ThenBy(w =>
+            var hcodesOrdered = details.WasteType.HCodes.WasteCodes.OrderBy(w => Regex.Match(!string.IsNullOrEmpty(w.Name) ? w.Name : string.Empty, @"(\D+)").Value).ThenBy(w =>
             {
                 double val;
-                double.TryParse(Regex.Match(w.Name, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
+                double.TryParse(Regex.Match(!string.IsNullOrEmpty(w.Name) ? w.Name : string.Empty, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToList();
             var unclassesOrdered = details.WasteType.UnClasses.WasteCodes.OrderBy(w => w.Name).ToList();

--- a/src/EA.Iws.Web/Areas/NotificationApplication/ViewModels/NotificationApplication/WasteCodeOverviewViewModel.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/ViewModels/NotificationApplication/WasteCodeOverviewViewModel.cs
@@ -74,16 +74,16 @@
             NationExportCode = classifyYourWasteInfo.NationExportCode;
             NationImportCode = classifyYourWasteInfo.NationImportCode;
             OtherCodes = classifyYourWasteInfo.OtherCodes;
-            YCodes = classifyYourWasteInfo.YCodes.OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
+            YCodes = classifyYourWasteInfo.YCodes.OrderBy(w => Regex.Match(!string.IsNullOrEmpty(w.Code) ? w.Code : string.Empty, @"(\D+)").Value).ThenBy(w =>
             {
                 double val;
-                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
+                double.TryParse(Regex.Match(!string.IsNullOrEmpty(w.Code) ? w.Code : string.Empty, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
-            HCodes = classifyYourWasteInfo.HCodes.OrderBy(w => Regex.Match(w.Code, @"(\D+)").Value).ThenBy(w =>
+            HCodes = classifyYourWasteInfo.HCodes.OrderBy(w => Regex.Match(!string.IsNullOrEmpty(w.Code) ? w.Code : string.Empty, @"(\D+)").Value).ThenBy(w =>
             {
                 double val;
-                double.TryParse(Regex.Match(w.Code, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
+                double.TryParse(Regex.Match(!string.IsNullOrEmpty(w.Code) ? w.Code : string.Empty, @"(\d+(\.\d*)?|\.\d+)").Value, out val);
                 return val;
             }).ToArray();
             UnClass = classifyYourWasteInfo.UnClass.OrderBy(w => w.Code).ToArray();


### PR DESCRIPTION
Regex matching throws exception if argument is null. Added extra check when doing the ordering of Waste codes.

Applied to both Import and Export overview screens.