### PR TITLE
Hotfix/notification audit history

### DIFF
--- a/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationApplication/ChemicalCompositionControllerTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationApplication/ChemicalCompositionControllerTests.cs
@@ -1,5 +1,9 @@
 ﻿namespace EA.Iws.Web.Tests.Unit.Controllers.NotificationApplication
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Web.Mvc;
     using Areas.NotificationApplication.Controllers;
     using Areas.NotificationApplication.ViewModels.ChemicalComposition;
     using Core.Notification.Audit;
@@ -7,11 +11,8 @@
     using FakeItEasy;
     using Mappings;
     using Prsd.Core.Mediator;
+    using Requests.Notification;
     using Requests.WasteType;
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Web.Mvc;
     using Web.Infrastructure;
     using Web.ViewModels.Shared;
     using Xunit;
@@ -40,7 +41,22 @@
                     }
                 });
 
+            A.CallTo(
+                () => mediator.SendAsync(A<GetNotificationAuditTable>.That.Matches
+                (p => p.NotificationId == notificationId)))
+                .Returns(CreateTestAuditTable());
+            
             A.CallTo(() => auditService.AddAuditEntry(this.mediator, notificationId, "user", NotificationAuditType.Added, NotificationAuditScreenType.ChemicalComposition));
+        }
+
+        private NotificationAuditTable CreateTestAuditTable()
+        {
+            NotificationAuditTable table = new NotificationAuditTable();
+
+            table.TableData = new List<NotificationAuditForDisplay>();
+            table.TableData.Add(new NotificationAuditForDisplay(string.Empty, NotificationAuditScreenType.ChemicalComposition.ToString(), NotificationAuditType.Added.ToString(), DateTime.Now));
+
+            return table;
         }
 
         [Theory]

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/FacilityController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/FacilityController.cs
@@ -347,7 +347,7 @@
                     model.NotificationId,
                     User.GetUserId(),
                     NotificationAuditType.Deleted,
-                    NotificationAuditScreenType.SiteOfExport);
+                    NotificationAuditScreenType.RecoverySite);
                 }
 
                 return RedirectToAction("List", "Facility", new { id = model.NotificationId, backToOverview });


### PR DESCRIPTION
PBI 65804
Tasks: 66584 and 66582

WIth the chemical composition bug, if the type is changed on the first screen, when you get to the continued screen, it's a completly new object and so the existing code thought it was a create. New code to fix this, gets the audit type of the first screen and if it's created then we know it's a create, otherwise do normal checks to see if it needs updating.
