### PR TITLE
Feature/receipt recovery apply prenote updates

### DIFF
--- a/src/EA.Iws.Core/EA.Iws.Core.csproj
+++ b/src/EA.Iws.Core/EA.Iws.Core.csproj
@@ -168,7 +168,7 @@
     <Compile Include="MovementReceipt\Decision.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryFileRules.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryRulesSummary.cs" />
-    <Compile Include="Movement\BulkReceiptRecovery\ContentRuleResult.cs" />
+    <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryContentRuleResult.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryColumnIndex.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryContentRules.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\IReceiptRecoveryContentRule.cs" />

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/IReceiptRecoveryContentRule.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/IReceiptRecoveryContentRule.cs
@@ -6,6 +6,6 @@
 
     public interface IReceiptRecoveryContentRule
     {
-        Task<ContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId);
+        Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId);
     }
 }

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRuleResult.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRuleResult.cs
@@ -2,9 +2,9 @@
 {
     using Rules;
 
-    public class ContentRuleResult<ReceiptRecoveryContentRules>
+    public class ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>
     {
-        public ContentRuleResult(ReceiptRecoveryContentRules rule, MessageLevel messageLevel, string errorMessage)
+        public ReceiptRecoveryContentRuleResult(ReceiptRecoveryContentRules rule, MessageLevel messageLevel, string errorMessage)
         {
             Rule = rule;
             MessageLevel = messageLevel;

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRules.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRules.cs
@@ -4,6 +4,10 @@
 
     public enum ReceiptRecoveryContentRules
     {
+        [Display(Name = "The maximum number of shipments that can be uploaded is {0}")]
+        MaximumShipments,
+        [Display(Name = "You can't create {0} shipment(s), there is missing notification and shipment number.")]
+        MissingShipmentNumbers,
         [Display(Name = "Shipment number {0}: there is missing data.")]
         MissingData
     }

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRules.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryContentRules.cs
@@ -4,8 +4,6 @@
 
     public enum ReceiptRecoveryContentRules
     {
-        [Display(Name = "We think the first row was header data and have removed it. If the data was not header data, please check the first row and try to upload again. If the data was header data, and there are no errors, press continue.")]
-        HeaderDataRemoved,
         [Display(Name = "Shipment number {0}: there is missing data.")]
         MissingData
     }

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryRulesSummary.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryRulesSummary.cs
@@ -10,7 +10,7 @@
     {
         public IEnumerable<RuleResult<ReceiptRecoveryFileRules>> FileRulesResults { get; set; }
 
-        public IEnumerable<ContentRuleResult<ReceiptRecoveryContentRules>> ContentRulesResults { get; set; }
+        public IEnumerable<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> ContentRulesResults { get; set; }
 
         public IEnumerable<int> ShipmentNumbers { get; set; }
 
@@ -31,13 +31,13 @@
         public ReceiptRecoveryRulesSummary()
         {
             FileRulesResults = new List<RuleResult<ReceiptRecoveryFileRules>>();
-            ContentRulesResults = new List<ContentRuleResult<ReceiptRecoveryContentRules>>();
+            ContentRulesResults = new List<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>>();
         }
 
         public ReceiptRecoveryRulesSummary(IEnumerable<RuleResult<ReceiptRecoveryFileRules>> fileRules)
         {
             FileRulesResults = fileRules ?? new List<RuleResult<ReceiptRecoveryFileRules>>();
-            ContentRulesResults = new List<ContentRuleResult<ReceiptRecoveryContentRules>>(); 
+            ContentRulesResults = new List<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>>(); 
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandler.cs
@@ -16,6 +16,7 @@
     {
         private readonly IEnumerable<IReceiptRecoveryContentRule> contentRules;
         private readonly IMap<DataTable, List<ReceiptRecoveryMovement>> mapper;
+        private const int MaxShipments = 50;
 
         public PerformReceiptRecoveryContentValidationHandler(IEnumerable<IReceiptRecoveryContentRule> contentRules,
             IMap<DataTable, List<ReceiptRecoveryMovement>> mapper)
@@ -43,28 +44,80 @@
             return result;
         }
 
-        private async Task<List<ContentRuleResult<ReceiptRecoveryContentRules>>> GetOrderedContentRules(List<ReceiptRecoveryMovement> movements,
+        private async Task<List<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>>> GetOrderedContentRules(List<ReceiptRecoveryMovement> movements,
             Guid notificationId)
         {
-            var rules = new List<ContentRuleResult<ReceiptRecoveryContentRules>>();
+            var rules = new List<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>>();
 
-            var missingData = await GetMissingDataResult(movements, notificationId);
+            var maxShipments = await GetMaxShipments(movements);
 
-            rules.Add(missingData);
+            rules.Add(maxShipments);
 
-            // Only run rest of validations if there are no missing/blank data.
-            if (missingData.MessageLevel == MessageLevel.Success)
+            if (maxShipments.MessageLevel == MessageLevel.Success)
             {
-                foreach (var rule in contentRules)
+                var missingNotificationShipment = await GetMissingNotificationShipmentNumbers(movements);
+
+                rules.Add(missingNotificationShipment);
+
+                if (missingNotificationShipment.MessageLevel == MessageLevel.Success)
                 {
-                    rules.Add(await rule.GetResult(movements, notificationId));
+                    var missingData = await GetMissingDataResult(movements, notificationId);
+
+                    rules.Add(missingData);
+
+                    // Only run rest of validations if there are no missing/blank data.
+                    if (missingData.MessageLevel == MessageLevel.Success)
+                    {
+                        foreach (var rule in contentRules)
+                        {
+                            rules.Add(await rule.GetResult(movements, notificationId));
+                        }
+                    }
                 }
             }
-
+            
             return rules.OrderBy(r => r.Rule).ToList();
         }
 
-        private async Task<ContentRuleResult<ReceiptRecoveryContentRules>> GetMissingDataResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
+        private static async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetMaxShipments(
+            IReadOnlyCollection<ReceiptRecoveryMovement> movements)
+        {
+            return await Task.Run(() =>
+            {
+                var result = movements.Count > MaxShipments ? MessageLevel.Error : MessageLevel.Success;
+
+                var errorMessage =
+                    string.Format(
+                        Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.MaximumShipments),
+                        MaxShipments);
+
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.MaximumShipments,
+                    result, errorMessage);
+            });
+        }
+
+        private static async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetMissingNotificationShipmentNumbers(
+            IReadOnlyCollection<ReceiptRecoveryMovement> movements)
+        {
+            return await Task.Run(() =>
+            {
+                var result = movements.Any(m => m.MissingNotificationNumber
+                                                || m.MissingShipmentNumber
+                                                || !m.ShipmentNumber.HasValue)
+                    ? MessageLevel.Error
+                    : MessageLevel.Success;
+
+                var errorMessage =
+                    string.Format(
+                        Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.MissingShipmentNumbers),
+                        movements.Count);
+
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.MissingShipmentNumbers,
+                    result, errorMessage);
+            });
+        }
+
+        private async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetMissingDataResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
         {
             return await Task.Run(() =>
             {
@@ -89,7 +142,7 @@
                 var shipmentNumbers = string.Join(", ", missingDataShipmentNumbers);
                 var errorMessage = string.Format(Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.MissingData), shipmentNumbers);
 
-                return new ContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.MissingData, missingDataResult, errorMessage);
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.MissingData, missingDataResult, errorMessage);
             });
         }
     }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandler.cs
@@ -30,9 +30,7 @@
 
             var movements = mapper.Map(message.DataTable);
 
-            var addFirstRowWarningRule = message.IsCsv && !CheckFirstRow(movements);
-
-            result.ContentRulesResults = await GetOrderedContentRules(movements, message.NotificationId, addFirstRowWarningRule);
+            result.ContentRulesResults = await GetOrderedContentRules(movements, message.NotificationId);
 
             if (result.IsContentRulesSuccess)
             {
@@ -46,16 +44,9 @@
         }
 
         private async Task<List<ContentRuleResult<ReceiptRecoveryContentRules>>> GetOrderedContentRules(List<ReceiptRecoveryMovement> movements,
-            Guid notificationId, bool addFirstRowWarningRule)
+            Guid notificationId)
         {
             var rules = new List<ContentRuleResult<ReceiptRecoveryContentRules>>();
-
-            if (addFirstRowWarningRule)
-            {
-                rules.Add(new ContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.HeaderDataRemoved,
-                    MessageLevel.Warning,
-                    Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.HeaderDataRemoved)));
-            }
 
             var missingData = await GetMissingDataResult(movements, notificationId);
 
@@ -100,24 +91,6 @@
 
                 return new ContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.MissingData, missingDataResult, errorMessage);
             });
-        }
-
-        private static bool CheckFirstRow(IList<ReceiptRecoveryMovement> movements)
-        {
-            if (!IsValidNotificationNumber(movements[(int)ReceiptRecoveryColumnIndex.NotificationNumber].NotificationNumber))
-            {
-                movements.RemoveAt(0);
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool IsValidNotificationNumber(string input)
-        {
-            var match = Regex.Match(input.Replace(" ", string.Empty), @"(GB)(\d{4})(\d{6})");
-
-            return match.Success;
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
@@ -63,12 +63,10 @@
             var validationSummary = await validator.GetValidationSummary(model.File, notificationId);
             var failedFileRules = validationSummary.FileRulesResults.Where(r => r.MessageLevel == MessageLevel.Error).Select(r => r.Rule).ToList();
             var failedContentRules = validationSummary.ContentRulesResults.Where(r => r.MessageLevel == MessageLevel.Error).ToList();
-            var warningContentRule = validationSummary.ContentRulesResults.Where(r => r.MessageLevel == MessageLevel.Warning).ToList();
             model.FailedFileRules = failedFileRules;
             model.FailedContentRules = failedContentRules;
-            model.WarningContentRules = warningContentRule;
 
-            if (model.ErrorsCount > 0 || model.WarningsCount > 0)
+            if (model.ErrorsCount > 0)
             {
                 return View("Errors", model);
             }

--- a/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadViewModel.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadViewModel.cs
@@ -31,17 +31,7 @@
 
         public List<ReceiptRecoveryFileRules> FailedFileRules { get; set; }
 
-        public List<ContentRuleResult<ReceiptRecoveryContentRules>> WarningContentRules { get; set; }
-
         public List<ContentRuleResult<ReceiptRecoveryContentRules>> FailedContentRules { get; set; }
-
-        public int WarningsCount
-        {
-            get
-            {
-                return WarningContentRules != null ? WarningContentRules.Count : 0;
-            }
-        }
 
         [Display(Name = "Upload the data file containing your receipt / recovery data")]
         public HttpPostedFileBase File { get; set; }

--- a/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadViewModel.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadViewModel.cs
@@ -31,7 +31,7 @@
 
         public List<ReceiptRecoveryFileRules> FailedFileRules { get; set; }
 
-        public List<ContentRuleResult<ReceiptRecoveryContentRules>> FailedContentRules { get; set; }
+        public List<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> FailedContentRules { get; set; }
 
         [Display(Name = "Upload the data file containing your receipt / recovery data")]
         public HttpPostedFileBase File { get; set; }


### PR DESCRIPTION
Following functionality implemented against prenotification bulk upload is now applied to receipt/recovery bulk upload:

- Removal of the 'CheckFirstRow' rule
- Addition of the 'MaximumShipments' rule
- Addition of the 'MissingShipmentNumbers' rule (would have been a waste of time to unpick logic when viewing the prenotification example. Needs to be added eventually anyway)