### PR TITLE
Feature/receipt recovery content validation mike

### DIFF
--- a/src/EA.Iws.Core/EA.Iws.Core.csproj
+++ b/src/EA.Iws.Core/EA.Iws.Core.csproj
@@ -166,6 +166,7 @@
     <Compile Include="MeansOfTransport\TransportMethod.cs" />
     <Compile Include="MovementOperation\MovementOperationData.cs" />
     <Compile Include="MovementReceipt\Decision.cs" />
+    <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryDataRow.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryFileRules.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryRulesSummary.cs" />
     <Compile Include="Movement\BulkReceiptRecovery\ReceiptRecoveryContentRuleResult.cs" />

--- a/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryDataRow.cs
+++ b/src/EA.Iws.Core/Movement/BulkReceiptRecovery/ReceiptRecoveryDataRow.cs
@@ -1,0 +1,11 @@
+﻿namespace EA.Iws.Core.Movement.BulkReceiptRecovery
+{
+    using System.Data;
+
+    public class ReceiptRecoveryDataRow
+    {
+        public DataRow DataRow { get; set; }
+
+        public bool IsReceivedDate { get; set; }
+    }
+}

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Movement\GetSubmittedMovementsHandlerTests.cs" />
     <Compile Include="Movement\GetNotificationIdByMovementIdHandlerTests.cs" />
     <Compile Include="Movement\RecordMovementStatusChangeTest.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandlerTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PerformBulkUploadContentValidationHandlerTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -144,6 +144,7 @@
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateFormatRuleTests.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateValidationRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandlerTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PerformBulkUploadContentValidationHandlerTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PrenotificationContentDateHistoricRuleTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Movement\RecordMovementStatusChangeTest.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRuleTests.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateFormatRuleTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandlerTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PerformBulkUploadContentValidationHandlerTests.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PrenotificationContentDateHistoricRuleTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryNotificationNumberRuleTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryNotificationNumberRuleTests.cs
@@ -1,0 +1,70 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
+    using Domain.NotificationApplication;
+    using FakeItEasy;
+    using RequestHandlers.NotificationMovements.BulkReceiptRecovery;
+    using Xunit;
+
+    public class ReceiptRecoveryNotificationNumberRuleTests
+    {
+        private readonly ReceiptRecoveryNotificationNumberRule rule;
+        private readonly INotificationApplicationRepository repository;
+        private readonly Guid notificationId;
+        private readonly string notificationNumber;
+
+        public ReceiptRecoveryNotificationNumberRuleTests()
+        {
+            repository = A.Fake<INotificationApplicationRepository>();
+
+            rule = new ReceiptRecoveryNotificationNumberRule(repository);
+            notificationId = Guid.NewGuid();
+            notificationNumber = Guid.NewGuid().ToString();
+        }
+
+        [Fact]
+        public async Task GetResult_NotificationNumber_Success()
+        {
+            A.CallTo(() => repository.GetNumber(notificationId))
+                .Returns(notificationNumber);
+
+            var result = await rule.GetResult(GetTestData(), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.WrongNotificationNumber, result.Rule);
+            Assert.Equal(MessageLevel.Success, result.MessageLevel);
+        }
+
+        [Fact]
+        public async Task GetResult_NotificationNumber_Error()
+        {
+            A.CallTo(() => repository.GetNumber(notificationId))
+                .Returns(Guid.NewGuid().ToString());
+
+            var result = await rule.GetResult(GetTestData(), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.WrongNotificationNumber, result.Rule);
+            Assert.Equal(MessageLevel.Error, result.MessageLevel);
+        }
+
+        private List<ReceiptRecoveryMovement> GetTestData()
+        {
+            return new List<ReceiptRecoveryMovement>()
+            {
+                new ReceiptRecoveryMovement()
+                {
+                    ShipmentNumber = 1,
+                    NotificationNumber = notificationNumber
+                },
+                new ReceiptRecoveryMovement()
+                {
+                    ShipmentNumber = 2,
+                    NotificationNumber = notificationNumber
+                }
+            };
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRuleTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRuleTests.cs
@@ -1,0 +1,55 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
+    using RequestHandlers.NotificationMovements.BulkReceiptRecovery;
+    using Xunit;
+
+    public class ReceiptRecoveryReceiptDateFormatRuleTests
+    {
+        private readonly ReceiptRecoveryReceiptDateFormatRule rule;
+        private readonly Guid notificationId;
+
+        public ReceiptRecoveryReceiptDateFormatRuleTests()
+        {
+            rule = new ReceiptRecoveryReceiptDateFormatRule();
+            notificationId = Guid.NewGuid();
+        }
+
+        [Fact]
+        public async Task GetResult_ReceiptDateFormat_Success()
+        {
+            var result = await rule.GetResult(GetTestData(false), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.ReceiptDateFormat, result.Rule);
+            Assert.Equal(MessageLevel.Success, result.MessageLevel);
+        }
+
+        [Fact]
+        public async Task GetResult_ReceiptDateFormat_Error()
+        {
+            var result = await rule.GetResult(GetTestData(true), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.ReceiptDateFormat, result.Rule);
+            Assert.Equal(MessageLevel.Error, result.MessageLevel);
+        }
+
+        private List<ReceiptRecoveryMovement> GetTestData(bool invalidFormat)
+        {
+            DateTime? invalidDate = null;
+            DateTime? validDate = DateTime.UtcNow;
+            return new List<ReceiptRecoveryMovement>()
+            {
+                new ReceiptRecoveryMovement()
+                {
+                    ShipmentNumber = 1,
+                    ReceivedDate = invalidFormat ? invalidDate : validDate,
+                    MissingReceivedDate = false
+                }
+            };
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateValidationRuleTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateValidationRuleTests.cs
@@ -1,0 +1,81 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
+    using Domain.Movement;
+    using FakeItEasy;
+    using RequestHandlers.NotificationMovements.BulkReceiptRecovery;
+    using TestHelpers.DomainFakes;
+    using Xunit;
+
+    public class ReceiptRecoveryReceiptDateValidationRuleTests
+    {
+        private readonly ReceiptRecoveryReceiptDateValidationRule rule;
+        private readonly IMovementRepository repository;
+        private readonly Guid notificationId;
+
+        public ReceiptRecoveryReceiptDateValidationRuleTests()
+        {
+            repository = A.Fake<IMovementRepository>();
+            rule = new ReceiptRecoveryReceiptDateValidationRule(repository);
+            notificationId = Guid.NewGuid();
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        public async Task GetResult_ReceiptDateValidation_Success(bool isExistingMovementValid, bool isReceiptRecoveryValid)
+        {
+            A.CallTo(() => repository.GetAllMovements(notificationId)).Returns(GetTestData_ExistingMovements(isExistingMovementValid));
+
+            var result = await rule.GetResult(GetTestData_ReceiptRecoveryMovements(isReceiptRecoveryValid), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.ReceiptDateValidation, result.Rule);
+            Assert.Equal(MessageLevel.Success, result.MessageLevel);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task GetResult_ReceiptDateValidation_Error(bool isExistingMovementValid, bool isReceiptRecoveryValid)
+        {
+            A.CallTo(() => repository.GetAllMovements(notificationId)).Returns(GetTestData_ExistingMovements(isExistingMovementValid));
+
+            var result = await rule.GetResult(GetTestData_ReceiptRecoveryMovements(isReceiptRecoveryValid), notificationId);
+
+            Assert.Equal(ReceiptRecoveryContentRules.ReceiptDateValidation, result.Rule);
+            Assert.Equal(MessageLevel.Error, result.MessageLevel);
+        }
+
+        private List<Movement> GetTestData_ExistingMovements(bool isSuccess)
+        {
+            int dateModifier = isSuccess ? -2 : 2;
+            return new List<Movement>()
+            {
+                new TestableMovement()
+                {
+                    Number = 1,
+                    Date = DateTime.UtcNow.AddDays(dateModifier)
+                }
+            };
+        }
+
+        private List<ReceiptRecoveryMovement> GetTestData_ReceiptRecoveryMovements(bool isSuccess)
+        {
+            int dateModifier = isSuccess ? -1 : 1;
+            return new List<ReceiptRecoveryMovement>()
+            {
+                new ReceiptRecoveryMovement()
+                {
+                    ShipmentNumber = 1,
+                    ReceivedDate = DateTime.UtcNow.AddDays(dateModifier)
+                }
+            };
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
+++ b/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
@@ -462,6 +462,7 @@
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateFormatRule.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateValidationRule.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandler.cs" />
     <Compile Include="NotificationMovements\Create\GetInternalMovementSummaryHandler.cs" />
     <Compile Include="NotificationMovements\Create\GetRemainingShipmentsHandler.cs" />

--- a/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
+++ b/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
@@ -461,6 +461,7 @@
     <Compile Include="NotificationMovements\BulkPrenotification\PrenotificationContentThreeWorkingDaysRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRule.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateFormatRule.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandler.cs" />
     <Compile Include="NotificationMovements\Create\GetInternalMovementSummaryHandler.cs" />
     <Compile Include="NotificationMovements\Create\GetRemainingShipmentsHandler.cs" />
@@ -544,6 +545,11 @@
     <Compile Include="NotificationMovements\Mappings\PackagingTypesDataRowMap.cs" />
     <Compile Include="NotificationMovements\Mappings\PrenotificationMovementCollectionMap.cs" />
     <Compile Include="NotificationMovements\Mappings\QuantityDataRowMap.cs" />
+    <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMappings\DateDataRowMap.cs" />
+    <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMappings\NotificationNumberDataRowMap.cs" />
+    <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMappings\QuantityDataRowMap.cs" />
+    <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMappings\ShipmentNumberDataRowMap.cs" />
+    <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMappings\ShipmentQuantityUnitDataRowMap.cs" />
     <Compile Include="NotificationMovements\Mappings\ReceiptRecoveryMovementCollectionMap.cs" />
     <Compile Include="NotificationMovements\Mappings\ShipmentDatesMap.cs" />
     <Compile Include="NotificationMovements\Mappings\ShipmentNumberDataRowMap.cs" />

--- a/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
+++ b/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
@@ -459,6 +459,7 @@
     <Compile Include="NotificationMovements\BulkPrenotification\PrenotificationQuantityUnitRule.cs" />
     <Compile Include="NotificationMovements\BulkPrenotification\PrenotificationThreeWorkingDaysConsentRule.cs" />
     <Compile Include="NotificationMovements\BulkPrenotification\PrenotificationContentThreeWorkingDaysRule.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkUpload\GetBulkUploadTemplateHandler.cs" />
     <Compile Include="NotificationMovements\Create\GetInternalMovementSummaryHandler.cs" />

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryNotificationNumberRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryNotificationNumberRule.cs
@@ -1,0 +1,39 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
+    using Domain.NotificationApplication;
+
+    public class ReceiptRecoveryNotificationNumberRule : IReceiptRecoveryContentRule
+    {
+        private readonly INotificationApplicationRepository notificationApplicationRepository;
+
+        public ReceiptRecoveryNotificationNumberRule(INotificationApplicationRepository notificationApplicationRepository)
+        {
+            this.notificationApplicationRepository = notificationApplicationRepository;
+        }
+
+        public async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
+        {
+            var notificationNumber = await notificationApplicationRepository.GetNumber(notificationId);
+            return await Task.Run(() =>
+            {
+                var shipments =
+                    movements.Where(m => m.ShipmentNumber.HasValue && m.NotificationNumber != notificationNumber)
+                        .Select(m => m.ShipmentNumber.Value)
+                        .ToList();
+
+                var result = shipments.Any() ? MessageLevel.Error : MessageLevel.Success;
+                
+                var shipmentNumbers = string.Join(", ", shipments);
+                var errorMessage = string.Format(Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.WrongNotificationNumber), shipmentNumbers, notificationNumber);
+
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.WrongNotificationNumber, result, errorMessage);
+            });
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRule.cs
@@ -4,8 +4,8 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using EA.Iws.Core.Movement.BulkReceiptRecovery;
-    using EA.Iws.Core.Rules;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
 
     public class ReceiptRecoveryReceiptDateFormatRule : IReceiptRecoveryContentRule
     {

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateFormatRule.cs
@@ -1,0 +1,30 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using EA.Iws.Core.Movement.BulkReceiptRecovery;
+    using EA.Iws.Core.Rules;
+
+    public class ReceiptRecoveryReceiptDateFormatRule : IReceiptRecoveryContentRule
+    {
+        public async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
+        {
+            return await Task.Run(() =>
+            {
+                var shipments =
+                    movements.Where(m => m.ShipmentNumber.HasValue && !m.ReceivedDate.HasValue)
+                        .Select(m => m.ShipmentNumber.Value)
+                        .ToList();
+
+                var result = shipments.Any() ? MessageLevel.Error : MessageLevel.Success;
+
+                var shipmentNumbers = string.Join(", ", shipments);
+                var errorMessage = string.Format(Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.ReceiptDateFormat), shipmentNumbers);
+
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.ReceiptDateFormat, result, errorMessage);
+            });
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateValidationRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryReceiptDateValidationRule.cs
@@ -1,0 +1,55 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Rules;
+    using Domain.Movement;
+
+    public class ReceiptRecoveryReceiptDateValidationRule : IReceiptRecoveryContentRule
+    {
+        private readonly IMovementRepository repository;
+
+        public ReceiptRecoveryReceiptDateValidationRule(IMovementRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
+        {
+            return await Task.Run(() =>
+            {
+                var shipments = new List<int>();
+                var existingMovements = repository.GetAllMovements(notificationId).Result;
+
+                foreach (ReceiptRecoveryMovement movement in movements)
+                {
+                    if (movement.ShipmentNumber.HasValue && movement.ReceivedDate.HasValue)
+                    {
+                        try
+                        {
+                            var existingMovement = existingMovements.Where(m => m.Number == movement.ShipmentNumber).Single();
+                            if (movement.ReceivedDate > DateTime.UtcNow || movement.ReceivedDate < existingMovement.Date)
+                            {
+                                shipments.Add(movement.ShipmentNumber.Value);
+                            }
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // if there is no existing movement catch the error and ignore
+                        }
+                    }
+                }
+
+                var result = shipments.Any() ? MessageLevel.Error : MessageLevel.Success;
+
+                var shipmentNumbers = string.Join(", ", shipments);
+                var errorMessage = string.Format(Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.ReceiptDateValidation), shipmentNumbers);
+
+                return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.ReceiptDateValidation, result, errorMessage);
+            });
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/DateDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/DateDataRowMap.cs
@@ -1,0 +1,42 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.Mappings.ReceiptRecoveryMappings
+{
+    using System;
+    using System.Data;
+    using System.Globalization;
+    using Core.Movement.BulkReceiptRecovery;
+    using Prsd.Core.Mapper;
+
+    public class ActualDateOfShipmentDataRowMap : IMap<ReceiptRecoveryDataRow, DateTime?>
+    {
+        private readonly string[] formats = { "dd/MM/yyyy", "d/MM/yyyy", "d/M/yyyy", "dd/M/yyyy" };
+
+        public DateTime? Map(ReceiptRecoveryDataRow source)
+        {
+            DateTime? result = null;
+
+            try
+            {
+                int index = source.IsReceivedDate ? (int)ReceiptRecoveryColumnIndex.Received : (int)ReceiptRecoveryColumnIndex.RecoveredDisposed;
+                var data = source.DataRow.ItemArray[index].ToString();
+                data = data.Trim().Split(' ')[0];
+                DateTime parsed;
+
+                foreach (var format in formats)
+                {
+                    if (DateTime.TryParseExact(data, format, CultureInfo.InvariantCulture, DateTimeStyles.None,
+                        out parsed))
+                    {
+                        result = parsed;
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/NotificationNumberDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/NotificationNumberDataRowMap.cs
@@ -1,0 +1,44 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.Mappings.ReceiptRecoveryMappings
+{
+    using System.Text.RegularExpressions;
+    using Core.Movement.BulkReceiptRecovery;
+    using Prsd.Core.Mapper;
+
+    public class NotificationNumberDataRowMap : IMap<ReceiptRecoveryDataRow, string>
+    {
+        private static readonly Regex NotificationNumberRegex = new Regex(@"(GB)(\d{4})(\d{6})", RegexOptions.Compiled);
+
+        public string Map(ReceiptRecoveryDataRow source)
+        {
+            string result = null;
+
+            try
+            {
+                result = source.DataRow.ItemArray[(int)ReceiptRecoveryColumnIndex.NotificationNumber].ToString();
+            }
+            catch
+            {
+                //ignored
+            }
+
+            return FormatNotificationNumber(result);
+        }
+
+        private static string FormatNotificationNumber(string number)
+        {
+            if (string.IsNullOrWhiteSpace(number))
+            {
+                return string.Empty;
+            }
+
+            number = number.ToUpper().Replace(" ", string.Empty);
+
+            if (NotificationNumberRegex.IsMatch(number))
+            {
+                number = NotificationNumberRegex.Replace(number, "$1 $2 $3");
+            }
+
+            return number;
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/QuantityDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/QuantityDataRowMap.cs
@@ -1,0 +1,44 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.Mappings.ReceiptRecoveryMappings
+{
+    using System;
+    using System.Data;
+    using System.Globalization;
+    using Core.Movement.BulkReceiptRecovery;
+    using Prsd.Core.Mapper;
+
+    public class QuantityDataRowMap : IMap<ReceiptRecoveryDataRow, decimal?>
+    {
+        public decimal? Map(ReceiptRecoveryDataRow source)
+        {
+            decimal? result = null;
+
+            try
+            {
+                var val = source.DataRow.ItemArray[(int)ReceiptRecoveryColumnIndex.Quantity].ToString();
+                decimal parsed;
+
+                if (decimal.TryParse(val, NumberStyles.AllowDecimalPoint, new NumberFormatInfo(), out parsed))
+                {
+                    if (NumberIsValid(parsed) && parsed > 0)
+                    {
+                        result = parsed;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return result;
+        }
+
+        private static bool NumberIsValid(decimal number)
+        {
+            var maxNumber = (long)Math.Pow(10, 18) - 1;
+            var minNumber = 0 - maxNumber;
+
+            return number > minNumber && number < maxNumber;
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/ShipmentNumberDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/ShipmentNumberDataRowMap.cs
@@ -1,0 +1,30 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.Mappings.ReceiptRecoveryMappings
+{
+    using Core.Movement.BulkReceiptRecovery;
+    using Prsd.Core.Mapper;
+
+    public class ShipmentNumberDataRowMap : IMap<ReceiptRecoveryDataRow, int?>
+    {
+        public int? Map(ReceiptRecoveryDataRow source)
+        {
+            int? result = null;
+
+            try
+            {
+                var val = source.DataRow.ItemArray[(int)ReceiptRecoveryColumnIndex.ShipmentNumber].ToString();
+                int parsed;
+
+                if (int.TryParse(val, out parsed))
+                {
+                    result = parsed;
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/ShipmentQuantityUnitDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMappings/ShipmentQuantityUnitDataRowMap.cs
@@ -1,0 +1,36 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.Mappings.ReceiptRecoveryMappings
+{
+    using System;
+    using Core.Movement.BulkReceiptRecovery;
+    using Core.Shared;
+    using Prsd.Core.Mapper;
+
+    public class ShipmentQuantityUnitDataRowMap : IMap<ReceiptRecoveryDataRow, ShipmentQuantityUnits?>
+    {
+        public ShipmentQuantityUnits? Map(ReceiptRecoveryDataRow source)
+        {
+            ShipmentQuantityUnits? result = null;
+
+            try
+            {
+                ShipmentQuantityUnits parsed;
+                var data = source.DataRow.ItemArray[(int)ReceiptRecoveryColumnIndex.Unit].ToString();
+
+                // Small 'hack' when this is supplied as the unit.
+                data = data == "m3" ? "CubicMetres" : data;
+
+                if (Enum.TryParse(data, out parsed) &&
+                    Enum.IsDefined(typeof(ShipmentQuantityUnits), parsed))
+                {
+                    result = parsed;
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMovementCollectionMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ReceiptRecoveryMovementCollectionMap.cs
@@ -4,27 +4,25 @@
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using Core.Movement.BulkReceiptRecovery;
     using Core.Shared;
     using Prsd.Core.Mapper;
 
     public class ReceiptRecoveryMovementCollectionMap : IMap<DataTable, List<ReceiptRecoveryMovement>>
     {
-        private readonly IMap<DataRow, string> notificationNumberMapper;
-        private readonly IMap<DataRow, int?> shipmentNumberMapper;
-        private readonly IMap<DataRow, DateTime?> receivedDateMapper;
-        private readonly IMap<DataRow, decimal?> quantityMapper;
-        private readonly IMap<DataRow, ShipmentQuantityUnits?> unitsMapper;
-        private readonly IMap<DataRow, DateTime?> recoveredDisposedDateMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, string> notificationNumberMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, int?> shipmentNumberMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, DateTime?> receivedDateMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, decimal?> quantityMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, ShipmentQuantityUnits?> unitsMapper;
+        private readonly IMap<ReceiptRecoveryDataRow, DateTime?> recoveredDisposedDateMapper;
 
-        public ReceiptRecoveryMovementCollectionMap(IMap<DataRow, string> notificationNumberMapper,
-            IMap<DataRow, int?> shipmentNumberMapper,
-            IMap<DataRow, DateTime?> receivedDateMapper,
-            IMap<DataRow, decimal?> quantityMapper,
-            IMap<DataRow, ShipmentQuantityUnits?> unitsMapper,
-            IMap<DataRow, DateTime?> recoveredDisposedDateMapper)
+        public ReceiptRecoveryMovementCollectionMap(IMap<ReceiptRecoveryDataRow, string> notificationNumberMapper,
+            IMap<ReceiptRecoveryDataRow, int?> shipmentNumberMapper,
+            IMap<ReceiptRecoveryDataRow, DateTime?> receivedDateMapper,
+            IMap<ReceiptRecoveryDataRow, decimal?> quantityMapper,
+            IMap<ReceiptRecoveryDataRow, ShipmentQuantityUnits?> unitsMapper,
+            IMap<ReceiptRecoveryDataRow, DateTime?> recoveredDisposedDateMapper)
         {
             this.notificationNumberMapper = notificationNumberMapper;
             this.shipmentNumberMapper = shipmentNumberMapper;
@@ -36,22 +34,34 @@
 
         public List<ReceiptRecoveryMovement> Map(DataTable source)
         {
-            return source.AsEnumerable().Select(data =>
-                new ReceiptRecoveryMovement()
+            return source.AsEnumerable().Select(data => 
+            {
+                var dataRow = new ReceiptRecoveryDataRow()
                 {
-                    NotificationNumber = notificationNumberMapper.Map(data),
-                    ShipmentNumber = shipmentNumberMapper.Map(data),
-                    ReceivedDate = receivedDateMapper.Map(data),
-                    Quantity = quantityMapper.Map(data),
-                    Unit = unitsMapper.Map(data),
-                    RecoveredDisposedDate = recoveredDisposedDateMapper.Map(data),
+                    DataRow = data,
+                    IsReceivedDate = false
+                };
+                var dataRowReceivedData = new ReceiptRecoveryDataRow()
+                {
+                    DataRow = data,
+                    IsReceivedDate = true
+                };
+                return new ReceiptRecoveryMovement()
+                {
+                    NotificationNumber = notificationNumberMapper.Map(dataRow),
+                    ShipmentNumber = shipmentNumberMapper.Map(dataRow),
+                    ReceivedDate = receivedDateMapper.Map(dataRowReceivedData),
+                    Quantity = quantityMapper.Map(dataRow),
+                    Unit = unitsMapper.Map(dataRow),
+                    RecoveredDisposedDate = recoveredDisposedDateMapper.Map(dataRow),
                     MissingNotificationNumber = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.NotificationNumber].ToString()),
                     MissingShipmentNumber = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.ShipmentNumber].ToString()),
                     MissingReceivedDate = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.Received].ToString()),
                     MissingQuantity = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.Quantity].ToString()),
                     MissingUnits = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.Unit].ToString()),
                     MissingRecoveredDisposedDate = string.IsNullOrWhiteSpace(data.ItemArray[(int)ReceiptRecoveryColumnIndex.RecoveredDisposed].ToString())
-                }).ToList();
+                };
+            }).ToList();
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers/RequestHandlerModule.cs
+++ b/src/EA.Iws.RequestHandlers/RequestHandlerModule.cs
@@ -10,6 +10,7 @@
     using Core.ComponentRegistration;
     using Core.Movement;
     using Core.Movement.BulkPrenotification;
+    using Core.Movement.BulkReceiptRecovery;
     using Decorators;
     using Documents;
     using Domain.ImportNotification;
@@ -79,6 +80,10 @@
             builder.RegisterAssemblyTypes(ThisAssembly)
                 .AssignableTo<IPrenotificationContentRule>()
                 .As<IPrenotificationContentRule>();
+
+            builder.RegisterAssemblyTypes(ThisAssembly)
+                .AssignableTo<IReceiptRecoveryContentRule>()
+                .As<IReceiptRecoveryContentRule>();
         }
 
         private static bool HasAsposeLicense()

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadResources.Designer.cs
@@ -269,7 +269,7 @@ namespace EA.Iws.Web.Areas.NotificationMovements.Views.ReceiptRecoveryBulkUpload
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download the bulk upload templates.
+        ///   Looks up a localized string similar to Download the data file templates.
         /// </summary>
         public static string TemplateLinkText {
             get {

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadResources.resx
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/ReceiptRecoveryBulkUploadResources.resx
@@ -136,7 +136,7 @@
     <value>If you leave the journey before adding your accompanying shipment movement documents, your bulk upload of the receipt and/or recovery data will not be saved.</value>
   </data>
   <data name="TemplateLinkText" xml:space="preserve">
-    <value>Download the bulk upload templates</value>
+    <value>Download the data file templates</value>
   </data>
   <data name="UploadReceiptRecoveryTabTitle" xml:space="preserve">
     <value>Receipt / Recovery Bulk Upload</value>


### PR DESCRIPTION
Following work completed:
- Corrected the data mapping for receipt recovery
- Updated the link as per Boma's identified error: task 67050
- Receipt/Recovery content rules will now be run
- Rule added for Receipt/Recovery: the notification number must be applicable to the particular notification
- Rule added for Receipt/Recovery: if the data file contains 'receipt date' (column 3) data, then this must be in dd/mm/yyyy format
- Rule added for Receipt/Recovery: if the data file contains 'receipt date' (column 3) data, it must not be in the future and must be after the 'actual date of shipment'
- Unit tests added for the 3 above validation rules