### PR TITLE
Feature/receipt recovery task 67058

### DIFF
--- a/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
@@ -113,7 +113,7 @@
         {
             if (!ModelState.IsValid)
             {
-                return View(model);
+                return RedirectToAction("Warning");
             }
 
             var validationSummary = await validator.GetShipmentMovementValidationSummary(model.File, notificationId);

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/Success.cshtml
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/Success.cshtml
@@ -49,6 +49,7 @@
                 <p>@string.Format(Resources.SuccessTextSingleShipment, Model.GetShipments)</p>
             }
         </div>
-
     </div>
 </div>
+
+@Html.ActionLink("Finish", "Index", "Options", new { area = "NotificationApplication", id = ViewContext.RouteData.Values["notificationId"] }, new { @class = "button" })


### PR DESCRIPTION
Implemented fix for task 67058: receipt/recovery documents page now redirects to warning page if document has not been provided.
Implemented fix for task 67062: added finish button to receipt/recovery success page.