### PR TITLE
Hotfix/bulk prenote error ordering

### DIFF
--- a/src/EA.Iws.Core/Movement/BulkPrenotification/PrenotificationContentRules.cs
+++ b/src/EA.Iws.Core/Movement/BulkPrenotification/PrenotificationContentRules.cs
@@ -36,11 +36,11 @@
         ConsentValidity,
         [Display(Name = "Shipment number {0}: the date of shipment is less than three working days from the notification expiry date. Remove the shipment data from the data file and use the existing ‘generate a prenotification’ journey to inform us of this shipment.")]
         ThreeWorkingDaysToConsentDate,
-        [Display(Name = "Shipment {0}: the actual shipment date is less than 3 working days.")]
-        ThreeWorkingDaysToShipment,
         [Display(Name = "Shipment {0}: the quantity of waste will exceed your permitted allowance and can't be prenotified.")]
         QuantityExceeded,
         [Display(Name = "Shipment {0}: the actual date of shipment is beyond your permitted Consent Window and therefore you are not allowed to prenotify this shipment.")]
-        BeyondConsentWindow
+        BeyondConsentWindow,
+        [Display(Name = "Shipment {0}: the actual shipment date is less than 3 working days.")]
+        ThreeWorkingDaysToShipment
     }
 }

--- a/src/EA.Iws.DataAccess/Draft/DraftMovementRepository.cs
+++ b/src/EA.Iws.DataAccess/Draft/DraftMovementRepository.cs
@@ -23,7 +23,7 @@
             this.userContext = userContext;
         }
 
-        public async Task<Guid> Add(Guid notificationId, List<PrenotificationMovement> movements, string fileName)
+        public async Task<Guid> AddPrenotifications(Guid notificationId, List<PrenotificationMovement> movements, string fileName)
         {
             Guid result;
 

--- a/src/EA.Iws.Domain/Movement/BulkUpload/IDraftMovementRepository.cs
+++ b/src/EA.Iws.Domain/Movement/BulkUpload/IDraftMovementRepository.cs
@@ -7,7 +7,7 @@
 
     public interface IDraftMovementRepository
     {
-        Task<Guid> Add(Guid notificationId, List<PrenotificationMovement> movements, string fileName);
+        Task<Guid> AddPrenotifications(Guid notificationId, List<PrenotificationMovement> movements, string fileName);
 
         Task<IEnumerable<DraftMovement>> GetDraftMovementById(Guid draftBulkUploadId);
 

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkUpload/PerformBulkUploadContentValidationHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkUpload/PerformBulkUploadContentValidationHandlerTests.cs
@@ -140,7 +140,7 @@
             var response = await handler.HandleAsync(message);
 
             Assert.False(response.IsContentRulesSuccess);
-            A.CallTo(() => repository.Add(A<Guid>.Ignored, A<List<PrenotificationMovement>>.Ignored, "Test")).MustNotHaveHappened();
+            A.CallTo(() => repository.AddPrenotifications(A<Guid>.Ignored, A<List<PrenotificationMovement>>.Ignored, "Test")).MustNotHaveHappened();
         }
 
         [Fact]
@@ -171,7 +171,7 @@
             var response = await handler.HandleAsync(message);
 
             Assert.True(response.IsContentRulesSuccess);
-            A.CallTo(() => repository.Add(A<Guid>.Ignored, A<List<PrenotificationMovement>>.Ignored, "Test"))
+            A.CallTo(() => repository.AddPrenotifications(A<Guid>.Ignored, A<List<PrenotificationMovement>>.Ignored, "Test"))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
     }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
@@ -18,6 +18,7 @@
         private readonly IMap<DataTable, List<PrenotificationMovement>> mapper;
         private readonly IDraftMovementRepository repository;
         private const int MaxShipments = 50;
+        private const PrenotificationContentRules LastRule = PrenotificationContentRules.ThreeWorkingDaysToShipment;
 
         public PerformPrenotificationContentValidationHandler(IEnumerable<IPrenotificationContentRule> contentRules,
             IMap<DataTable, List<PrenotificationMovement>> mapper,
@@ -79,7 +80,17 @@
                 rules.Add(await rule.GetResult(movements, notificationId));
             }
 
-            return rules.OrderBy(r => r.Rule).ToList();
+            var lastRuleResult = rules.FirstOrDefault(r => r.Rule == LastRule);
+
+            var orderedRules = rules.Where(r => r.Rule != LastRule).OrderBy(r =>
+            {
+                var shipments = r.ErrorMessage.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries)[0];
+                return shipments;
+            }).ThenBy(r => r.Rule).ToList();
+
+            orderedRules.Add(lastRuleResult);
+
+            return orderedRules;
         }
 
         private static async Task<PrenotificationContentRuleResult<PrenotificationContentRules>> GetMaxShipments(

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
@@ -88,7 +88,10 @@
                 return shipments;
             }).ThenBy(r => r.Rule).ToList();
 
-            orderedRules.Add(lastRuleResult);
+            if (lastRuleResult != null)
+            {
+                orderedRules.Add(lastRuleResult);
+            }
 
             return orderedRules;
         }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
@@ -42,7 +42,7 @@
                 result.ShipmentNumbers =
                     movements.Where(m => m.ShipmentNumber.HasValue).Select(m => m.ShipmentNumber.Value);
 
-                result.DraftBulkUploadId = await repository.Add(message.NotificationId, movements, message.FileName);
+                result.DraftBulkUploadId = await repository.AddPrenotifications(message.NotificationId, movements, message.FileName);
             }
 
             return result;

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/NotificationNumberDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/NotificationNumberDataRowMap.cs
@@ -34,12 +34,8 @@
 
             number = number.ToUpper().Replace(" ", string.Empty);
 
-            if (NotificationNumberRegex.IsMatch(number))
-            {
-                number = NotificationNumberRegex.Replace(number, "$1 $2 $3");
-            }
-
-            return number;
+            return NotificationNumberRegex.IsMatch(number) ? 
+                NotificationNumberRegex.Replace(number, "$1 $2 $3") : null;
         }
     }
 }


### PR DESCRIPTION
Fixing BUG 67112 - update ordering of error message displayed on the screen to order by shipment numbers then by the rule order. Make sure the 3 days to shipment rule is always displayed last as it has extra details/information.

TO-DO: apply to Receipt Recovery rules.