### PR TITLE
Save bulk receipt recovery data

### DIFF
--- a/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
+++ b/src/EA.Iws.RequestHandlers/EA.Iws.RequestHandlers.csproj
@@ -440,6 +440,7 @@
     <Compile Include="NotificationAssessment\SetExporterContactHandler.cs" />
     <Compile Include="NotificationAssessment\SetNewNumberOfShipmentsHandler.cs" />
     <Compile Include="NotificationAssessment\SetEntryPointHandler.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\CreateReceiptRecoveryHandler.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\PerformReceiptRecoveryContentValidationHandler.cs" />
     <Compile Include="NotificationMovements\BulkPrenotification\CreatePrenotificationHandler.cs" />
     <Compile Include="NotificationMovements\BulkPrenotification\PrenotificationDateFutureRule.cs" />
@@ -465,7 +466,7 @@
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryRecoveryOnlyRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryRecoveryQuantityUnitRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryShipmentMustBePrenotifiedRule.cs" />
-	<Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRule.cs" />
+    <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryNotificationNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryDuplicateShipmentNumberRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryQuantityPrecisionRule.cs" />
     <Compile Include="NotificationMovements\BulkReceiptRecovery\ReceiptRecoveryReceiptDateFormatRule.cs" />

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/CreateReceiptRecoveryHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/CreateReceiptRecoveryHandler.cs
@@ -1,0 +1,117 @@
+﻿namespace EA.Iws.RequestHandlers.NotificationMovements.BulkReceiptRecovery
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DataAccess;
+    using Domain.FileStore;
+    using Domain.Movement;
+    using Domain.Movement.BulkUpload;
+    using Domain.NotificationApplication;
+    using Prsd.Core.Domain;
+    using Prsd.Core.Mediator;
+    using Requests.NotificationMovements.BulkUpload;
+
+    public class CreateReceiptRecoveryHandler : IRequestHandler<CreateReceiptRecovery, bool>
+    {
+        private readonly IDraftMovementRepository draftMovementRepository;
+        private readonly IMovementRepository movementRepository;
+        private readonly IwsContext context;
+        private readonly IUserContext userContext;
+        private readonly IFileRepository fileRepository;
+        private readonly CertificateFactory certificateFactory;
+        private readonly CertificateOfReceiptNameGenerator receiptNameGenerator;
+        private readonly CertificateOfRecoveryNameGenerator recoveryNameGenerator;
+
+        public CreateReceiptRecoveryHandler(IDraftMovementRepository draftMovementRepository,
+            IMovementRepository movementRepository,
+            IwsContext context,
+            IUserContext userContext,
+            IFileRepository fileRepository,
+            CertificateFactory certificateFactory,
+            CertificateOfReceiptNameGenerator receiptNameGenerator,
+            CertificateOfRecoveryNameGenerator recoveryNameGenerator)
+        {
+            this.draftMovementRepository = draftMovementRepository;
+            this.movementRepository = movementRepository;
+            this.context = context;
+            this.userContext = userContext;
+            this.fileRepository = fileRepository;
+            this.certificateFactory = certificateFactory;
+            this.receiptNameGenerator = receiptNameGenerator;
+            this.recoveryNameGenerator = recoveryNameGenerator;
+        }
+
+        public async Task<bool> HandleAsync(CreateReceiptRecovery message)
+        {
+            using (var transaction = context.Database.BeginTransaction())
+            {
+                try
+                {
+                    var draftMovements = await draftMovementRepository.GetDraftMovementById(message.DraftBulkUploadId);
+
+                    if (!draftMovements.Any())
+                    {
+                        return false;
+                    }
+
+                    foreach (var draftMovement in draftMovements)
+                    {
+                        var movement = await movementRepository.GetByNumberOrDefault(draftMovement.ShipmentNumber,
+                            message.NotificationId);
+
+                        if (draftMovement.ReceivedDate.HasValue)
+                        {
+                            var fileId =
+                                await
+                                    SaveSupportingDocument(movement, receiptNameGenerator, message.SupportingDocument, message.FileExtension);
+
+                            movement.Receive(fileId, draftMovement.ReceivedDate.GetValueOrDefault(),
+                                new Domain.ShipmentQuantity(draftMovement.Quantity, draftMovement.Units),
+                                userContext.UserId);
+
+                            await context.SaveChangesAsync();
+                        }
+
+                        if (draftMovement.RecoveredDisposedDate.HasValue)
+                        {
+                            var fileId =
+                                await
+                                    SaveSupportingDocument(movement, recoveryNameGenerator, message.SupportingDocument,
+                                        message.FileExtension);
+
+                            movement.Complete(draftMovement.RecoveredDisposedDate.Value, fileId, userContext.UserId);
+
+                            await context.SaveChangesAsync();
+                        }
+                    }
+
+                    await draftMovementRepository.DeleteDraftMovementByNotificationId(message.NotificationId);
+                }
+                catch
+                {
+                    transaction.Rollback();
+                    throw;
+                }
+                transaction.Commit();
+            }
+
+            return true;
+        }
+
+        private async Task<Guid> SaveSupportingDocument(Movement movement,
+            ICertificateNameGenerator nameGenerator,
+            byte[] supportingDocument,
+            string fileExtension)
+        {
+            var receipt =
+                await certificateFactory.CreateForMovement(nameGenerator, movement, supportingDocument, fileExtension);
+
+            var fileId = await fileRepository.Store(receipt);
+
+            await context.SaveChangesAsync();
+
+            return fileId;
+        }
+    }
+}

--- a/src/EA.Iws.Requests/EA.Iws.Requests.csproj
+++ b/src/EA.Iws.Requests/EA.Iws.Requests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Movement\GetMovementsByIds.cs" />
     <Compile Include="Movement\GetNewMovementIdsByNotificationId.cs" />
     <Compile Include="Movement\GetNotificationNumberByMovementId.cs" />
+    <Compile Include="NotificationMovements\BulkUpload\CreateReceiptRecovery.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PerformReceiptRecoveryContentValidation.cs" />
     <Compile Include="NotificationMovements\BulkUpload\PerformPrenotificationContentValidation.cs" />
     <Compile Include="Movement\SetMovementComments.cs" />

--- a/src/EA.Iws.Requests/NotificationMovements/BulkUpload/CreateReceiptRecovery.cs
+++ b/src/EA.Iws.Requests/NotificationMovements/BulkUpload/CreateReceiptRecovery.cs
@@ -1,0 +1,30 @@
+﻿namespace EA.Iws.Requests.NotificationMovements.BulkUpload
+{
+    using System;
+    using Core.Authorization;
+    using Core.Authorization.Permissions;
+    using Prsd.Core.Mediator;
+
+    [RequestAuthorization(ExportMovementPermissions.CanEditExportMovements)]
+    public class CreateReceiptRecovery : IRequest<bool>
+    {
+        public Guid NotificationId { get; private set; }
+
+        public Guid DraftBulkUploadId { get; private set; }
+
+        public byte[] SupportingDocument { get; private set; }
+
+        public string FileExtension { get; private set; }
+
+        public CreateReceiptRecovery(Guid notificationId,
+            Guid draftBulkUploadId,
+            byte[] supportingDocument,
+            string fileExtension)
+        {
+            NotificationId = notificationId;
+            DraftBulkUploadId = draftBulkUploadId;
+            SupportingDocument = supportingDocument;
+            FileExtension = fileExtension;
+        }
+    }
+}


### PR DESCRIPTION
Save the uploaded data file as well as supporting document into the actual tables once all validations complete after uploading supporting document screen.

Task 67109