### PR TITLE
Receipt recovery error screen

### DIFF
--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkReceiptRecovery/PerformReceiptRecoveryContentValidationHandlerTests.cs
@@ -116,7 +116,7 @@
                 {
                     ShipmentNumber = 1,
                     MissingShipmentNumber = false,
-                    NotificationNumber = "invalid",
+                    NotificationNumber = null,
                     MissingNotificationNumber = false
                 }
             };
@@ -130,7 +130,7 @@
 
         [Theory]
         [MemberData("MissingReceiptData")]
-        public async Task MissingReceiptData_ContentRulesFailed(List<ReceiptRecoveryMovement> movements)
+        public async Task MissingReceiptAndRecoveryData_ContentRulesFailed(List<ReceiptRecoveryMovement> movements)
         {
             var notificationId = Guid.NewGuid();
             var summary = new ReceiptRecoveryRulesSummary();
@@ -141,23 +141,6 @@
             var response = await handler.HandleAsync(message);
 
             Assert.False(response.IsContentRulesSuccess);
-        }
-
-        [Theory]
-        [MemberData("CorrectReceiptData")]
-        public async Task MissingReceiptData_ContentRulesSuccess(List<ReceiptRecoveryMovement> movements)
-        {
-            var notificationId = Guid.NewGuid();
-            var summary = new ReceiptRecoveryRulesSummary();
-            var message = new PerformReceiptRecoveryContentValidation(summary, notificationId, new DataTable(), "Test", false);
-
-            A.CallTo(() => mapper.Map(A<DataTable>.Ignored)).Returns(movements);
-
-            var response = await handler.HandleAsync(message);
-            
-            Assert.True(response.ContentRulesResults
-                .Where(r => r.Rule == ReceiptRecoveryContentRules.MissingReceiptData)
-                .Single().MessageLevel == Core.Rules.MessageLevel.Success);
         }
 
         [Fact]
@@ -225,6 +208,7 @@
                                 NotificationNumber = "GB 0001 123456",
                                 ShipmentNumber = 1,
                                 MissingReceivedDate = true,
+                                MissingRecoveredDisposedDate = true,
                                 MissingQuantity = false,
                                 MissingUnits = false
                             }
@@ -238,7 +222,8 @@
                             {
                                 NotificationNumber = "GB 0001 123456",
                                 ShipmentNumber = 2,
-                                MissingReceivedDate = false,
+                                MissingReceivedDate = true,
+                                MissingRecoveredDisposedDate = true,
                                 MissingQuantity = true,
                                 MissingUnits = false
                             }
@@ -255,30 +240,6 @@
                                 MissingReceivedDate = false,
                                 MissingQuantity = false,
                                 MissingUnits = true
-                            }
-                        }
-                    }
-                };
-            }
-        }
-
-        public static IEnumerable<object[]> CorrectReceiptData
-        {
-            get
-            {
-                return new[]
-                {
-                    new object[]
-                    {
-                        new List<ReceiptRecoveryMovement>()
-                        {
-                            new ReceiptRecoveryMovement()
-                            {
-                                NotificationNumber = "GB 0001 123456",
-                                ShipmentNumber = 1,
-                                MissingReceivedDate = false,
-                                MissingQuantity = false,
-                                MissingUnits = false
                             }
                         }
                     }

--- a/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/Errors.cshtml
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Views/ReceiptRecoveryBulkUpload/Errors.cshtml
@@ -32,10 +32,10 @@
                             {
                                 <div class="summary-error-row">
                                     <div class="grid-row">
-                                        <div class="column-two-thirds">
+                                        <div class="column-nine-tenths">
                                             @Html.Raw(EA.Prsd.Core.Helpers.EnumHelper.GetDisplayName(rule))
                                         </div>
-                                        <div class="column-third">
+                                        <div class="column-tenth">
                                             <img class="summary-error-icon" src="@Url.Content("~/Content/images/error-icon.png")" alt="">
                                         </div>
                                     </div>
@@ -48,10 +48,10 @@
                             {
                                 <div class="summary-error-row">
                                     <div class="grid-row">
-                                        <div class="column-two-thirds">
+                                        <div class="column-nine-tenths">
                                             @Html.Raw(rule.ErrorMessage)
                                         </div>
-                                        <div class="column-third">
+                                        <div class="column-tenth">
                                             <img class="summary-error-icon" src="@Url.Content("~/Content/images/error-icon.png")" alt="">
                                         </div>
                                     </div>
@@ -62,8 +62,9 @@
                 </details>
             </div>
         }
+        @Html.ActionLink(Resources.ReturnToUpload, "Upload", "ReceiptRecoveryBulkUpload", new { notificationId = @Model.NotificationId, area = "NotificationMovements" }, new { @class = "button" })
     </div>
 </div>
 
 
-@Html.ActionLink(Resources.ReturnToUpload, "Upload", "ReceiptRecoveryBulkUpload", new { notificationId = @Model.NotificationId, area = "NotificationMovements" }, new { @class = "button" })
+@Html.ActionLink(Resources.NotificationOptionsLink, "Index", "Options", new { id = @Model.NotificationId, area = "NotificationApplication" }, null)


### PR DESCRIPTION
Updating order of validation message for receipt recovery. Similar to fix applied for prenotification in #749 

BUG 67112.

Additional styling updates on the error screen copied prenotification changes in #735 