### PR TITLE
RequireCustomsOffices class no longer takes into account whether star…

### DIFF
--- a/src/EA.Iws.Domain.Tests.Unit/NotificationApplication/NotificationCustomsOfficeTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/NotificationApplication/NotificationCustomsOfficeTests.cs
@@ -49,7 +49,7 @@
         }
 
         [Fact]
-        public void SetExitCustomsOffice_NotRequired_Throws()
+        public void SetExitCustomsOffice_Required_European()
         {
             var stateOfExport = new StateOfExport(europeanCountry1, europeanCompetentAuthority1,
                 europeanEntryOrExitPoints1[0]);
@@ -60,9 +60,16 @@
             SetStateOfExport(stateOfExport);
             SetStateOfImport(stateOfImport);
 
-            Assert.Throws<InvalidOperationException>(
-                () =>
-                    transportRoute.SetExitCustomsOffice(new ExitCustomsOffice("test", "test", europeanCountry1)));
+            transportRoute.SetExitCustomsOffice(new ExitCustomsOffice("test", "test", europeanCountry1));
+            transportRoute.SetEntryCustomsOffice(new EntryCustomsOffice("test2", "test2", europeanCountry2));
+
+            Assert.Equal("test", transportRoute.ExitCustomsOffice.Name);
+            Assert.Equal("test", transportRoute.ExitCustomsOffice.Address);
+            Assert.Equal(europeanCountry1.Id, transportRoute.ExitCustomsOffice.Country.Id);
+
+            Assert.Equal("test2", transportRoute.EntryCustomsOffice.Name);
+            Assert.Equal("test2", transportRoute.EntryCustomsOffice.Address);
+            Assert.Equal(europeanCountry2.Id, transportRoute.EntryCustomsOffice.Country.Id);
         }
 
         [Fact]
@@ -106,7 +113,7 @@
         }
 
         [Fact]
-        public void SetEntryCustomsOffice_NotRequired_Throws()
+        public void SetEntryCustomsOffice_Required_BothEuropean()
         {
             var stateOfExport = new StateOfExport(europeanCountry1, europeanCompetentAuthority1,
                 europeanEntryOrExitPoints1[0]);
@@ -117,9 +124,16 @@
             SetStateOfExport(stateOfExport);
             SetStateOfImport(stateOfImport);
 
-            Assert.Throws<InvalidOperationException>(
-                () =>
-                    transportRoute.SetEntryCustomsOffice(new EntryCustomsOffice("test", "test", europeanCountry1)));
+            transportRoute.SetExitCustomsOffice(new ExitCustomsOffice("test", "test", europeanCountry1));
+            transportRoute.SetEntryCustomsOffice(new EntryCustomsOffice("test2", "test2", europeanCountry2));
+
+            Assert.Equal("test", transportRoute.ExitCustomsOffice.Name);
+            Assert.Equal("test", transportRoute.ExitCustomsOffice.Address);
+            Assert.Equal(europeanCountry1.Id, transportRoute.ExitCustomsOffice.Country.Id);
+
+            Assert.Equal("test2", transportRoute.EntryCustomsOffice.Name);
+            Assert.Equal("test2", transportRoute.EntryCustomsOffice.Address);
+            Assert.Equal(europeanCountry2.Id, transportRoute.EntryCustomsOffice.Country.Id);
         }
 
         [Fact]

--- a/src/EA.Iws.Domain.Tests.Unit/TransportRoute/RequiredCustomsOfficesTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/TransportRoute/RequiredCustomsOfficesTests.cs
@@ -129,7 +129,7 @@
 
             var result = requiredCustomsOffices.GetForTransportRoute(transportRoute);
 
-            Assert.Equal(CustomsOffices.None, result);
+            Assert.Equal(CustomsOffices.EntryAndExit, result);
         }
 
         [Fact]
@@ -144,7 +144,7 @@
 
             var result = requiredCustomsOffices.GetForTransportRoute(transportRoute);
 
-            Assert.Equal(CustomsOffices.Exit, result);
+            Assert.Equal(CustomsOffices.EntryAndExit, result);
         }
 
         [Fact]
@@ -211,7 +211,7 @@
 
             var result = requiredCustomsOffices.GetForTransportRoute(transportRoute);
 
-            Assert.Equal(CustomsOffices.Exit, result);
+            Assert.Equal(CustomsOffices.EntryAndExit, result);
         }
 
         [Fact]
@@ -227,7 +227,7 @@
 
             var result = requiredCustomsOffices.GetForTransportRoute(transportRoute);
 
-            Assert.Equal(CustomsOffices.None, result);
+            Assert.Equal(CustomsOffices.EntryAndExit, result);
         }
     }
 }

--- a/src/EA.Iws.Domain/TransportRoute/RequiredCustomsOffices.cs
+++ b/src/EA.Iws.Domain/TransportRoute/RequiredCustomsOffices.cs
@@ -11,21 +11,7 @@
             {
                 return CustomsOffices.TransitStatesNotSet;
             }
-
-            var isStartPointEU = transportRoute.StateOfExport.Country.IsEuropeanUnionMember;
-            var isEndPointEU = transportRoute.StateOfImport.Country.IsEuropeanUnionMember;
-            var areAllTransitStatesEU = isStartPointEU && isEndPointEU;
-
-            if (transportRoute.TransitStates != null)
-            {
-                areAllTransitStatesEU = transportRoute.TransitStates.All(ts => ts.Country.IsEuropeanUnionMember);
-            }
-
-            if (isEndPointEU)
-            {
-                return areAllTransitStatesEU ? CustomsOffices.None : CustomsOffices.EntryAndExit;
-            }
-            return CustomsOffices.Exit;
+            return CustomsOffices.EntryAndExit;
         }
     }
 }


### PR DESCRIPTION
PBI 66605

RequiredCustomsOffices class updated so it no longer takes into account whether start point and/or end point is in the EU. Method in class returns CustomsOffices.EntryAndExit, unless it is determined that CustomsOffices.TransitStatesNotSet is more appropriate.

Intentionally left the existence of all five CustomsOffices enum values despite Entry, Exit and None now being redundant. NoCustomsOffice.cshtml has not been deleted as logic still exists to direct to it, however it is no longer possible to take that path due to changes in RequiredCustomsOfficers class (can discuss if you believe we should remove).

Unit tests updated.