### PR TITLE
GetForTransportRoute now always returns EntryAndExit. Tests updated a…

### DIFF
--- a/src/EA.Iws.Domain.Tests.Unit/TransportRoute/RequiredCustomsOfficesTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/TransportRoute/RequiredCustomsOfficesTests.cs
@@ -115,7 +115,7 @@
         {
             var result = requiredCustomsOffices.GetForTransportRoute(transportRoute);
 
-            Assert.Equal(CustomsOffices.TransitStatesNotSet, result);
+            Assert.Equal(CustomsOffices.EntryAndExit, result);
         }
 
         [Fact]

--- a/src/EA.Iws.Domain/TransportRoute/RequiredCustomsOffices.cs
+++ b/src/EA.Iws.Domain/TransportRoute/RequiredCustomsOffices.cs
@@ -7,10 +7,6 @@
     {
         public CustomsOffices GetForTransportRoute(TransportRoute transportRoute)
         {
-            if (transportRoute == null || transportRoute.StateOfExport == null || transportRoute.StateOfImport == null)
-            {
-                return CustomsOffices.TransitStatesNotSet;
-            }
             return CustomsOffices.EntryAndExit;
         }
     }

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/CustomsOffice/SetExitCustomsOfficeForNotificationByIdHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/CustomsOffice/SetExitCustomsOfficeForNotificationByIdHandlerTests.cs
@@ -67,17 +67,6 @@
         }
 
         [Fact]
-        public async Task NotificationExistsButDoesNotRequireCustomsOffice_Throws()
-        {
-            var request = new SetExitCustomsOfficeForNotificationById(notificationId,
-                AnyName,
-                AnyAddress,
-                country.Id);
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => handler.HandleAsync(request));
-        }
-
-        [Fact]
         public async Task NotificationExistsAndRequiresExitCustomsOffice_SetsExitOffice()
         {
             transport.SetStateOfExportForNotification(stateOfExport);


### PR DESCRIPTION
All navigation for Customs Office and Transport Routes is now set to EntryAndExit, meaning that the Entry screen always needs to be resolved, followed by the Exit screen. Tests have been updated accordingly.