### PR TITLE
Bulk prenote error ordering

### DIFF
--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
@@ -83,7 +83,11 @@
             var lastRuleResult = rules.FirstOrDefault(r => r.Rule == LastRule);
 
             var orderedRules =
-                rules.Where(r => r.Rule != LastRule).OrderBy(r => r.MinShipmentNumber).ThenBy(r => r.Rule).ToList();
+                rules.Where(r => r.Rule != LastRule).OrderBy(r => r.MinShipmentNumber).ThenBy(r =>
+                {
+                    var shipments = r.ErrorMessage.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries)[0];
+                    return shipments;
+                }).ThenBy(r => r.Rule).ToList();
 
             if (lastRuleResult != null)
             {


### PR DESCRIPTION
Additional fix for BUG 67112 for Bulk Prenotes, re-work for #762.

In #762 - we are now sorting via the minimum shipment number in each validation message. However, there is an issue with this, because we get the following example below:

Shipment 1, 5, 7: [SOME TEXT HERE]
Shipment 1, 4, 7: [SOME TEXT HERE]

So as a result, we will first order by the minimum number, e.g. 1 then we re-order again by the entire string of "Shipment X,Y,Z".

**NOTE** - for Bulk Receipt Recovery, this is applied via #770 