### PR TITLE
Feature/finance report payment comments

### DIFF
--- a/src/EA.Iws.Core/Admin/Reports/FinanceReportData.cs
+++ b/src/EA.Iws.Core/Admin/Reports/FinanceReportData.cs
@@ -64,5 +64,8 @@
         public DateTime? PaymentReceivedDate { get; set; }
 
         public decimal? TotalBillable { get; set; }
+
+        [DisplayName("Payment Comments")]
+        public string PaymentComments { get; set; }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/Reports/FinanceReportRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Reports/FinanceReportRepository.cs
@@ -50,7 +50,8 @@
                     [ConsentFrom],
                     [ConsentTo],
                     [Status],
-                    [IsInterim]
+                    [IsInterim],
+                    [PaymentComments]
                   FROM
                     [Reports].[Finance]
                   WHERE

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -94,6 +94,8 @@
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190131-141400-add-bulk-prenote-draft.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190211-150500-update-draft.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190208-092800-update-movement-carrier-keys.sql" />
+    <Content Include="scripts\Update\0005-Beta\Sprint6\20190218-144700-alter-reports-finance-view.sql" />
+    <Content Include="scripts\Update\0005-Beta\Sprint6\20190218-134200-alter-reports-payments-view.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint6\20190214-133900-add-entryExitCustomsTable.sql" />
     <Content Include="unindexed-foreign-keys.sql" />
     <Content Include="scripts\Everytime\01-Functions\0003-Reports-PricingInfo.sql" />

--- a/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-134200-alter-reports-payments-view.sql
+++ b/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-134200-alter-reports-payments-view.sql
@@ -11,7 +11,7 @@ AS
         SUM(T.Debit) AS TotalRefunded,
         (SELECT TOP 1 [Date] FROM [Notification].[Transaction] WHERE NotificationId = N.Id AND Credit IS NOT NULL ORDER BY [Date] DESC) AS [LatestPaymentDate],
         (SELECT TOP 1 [Date] FROM [Notification].[Transaction] WHERE NotificationId = N.Id AND Debit IS NOT NULL ORDER BY [Date] DESC) AS [LatestRefundDate],
-		(SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
+        (SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
           FROM [Notification].[Transaction] T2
           WHERE T2.NotificationId = N.Id
 		  ORDER BY [Date] ASC
@@ -29,7 +29,7 @@ AS
         SUM(T.Debit) AS TotalRefunded,
         (SELECT TOP 1 [Date] FROM [ImportNotification].[Transaction] WHERE NotificationId = N.Id AND Credit IS NOT NULL ORDER BY [Date] DESC) AS [LatestPaymentDate],
         (SELECT TOP 1 [Date] FROM [ImportNotification].[Transaction] WHERE NotificationId = N.Id AND Debit IS NOT NULL ORDER BY [Date] DESC) AS [LatestRefundDate],
-		(SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
+        (SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
           FROM [ImportNotification].[Transaction] T2
           WHERE T2.NotificationId = N.Id
 		  ORDER BY [Date] ASC

--- a/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-134200-alter-reports-payments-view.sql
+++ b/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-134200-alter-reports-payments-view.sql
@@ -1,0 +1,40 @@
+IF OBJECT_ID('[Reports].[Payments]') IS NULL
+    EXEC('CREATE VIEW [Reports].[Payments] AS SELECT 1 AS [NOTHING];')
+GO
+
+ALTER VIEW [Reports].[Payments]
+AS
+    SELECT 
+        N.Id AS [NotificationId],
+        REPLACE(N.NotificationNumber, ' ', '') AS NotificationNumber,
+        SUM(T.Credit) AS TotalPaid,
+        SUM(T.Debit) AS TotalRefunded,
+        (SELECT TOP 1 [Date] FROM [Notification].[Transaction] WHERE NotificationId = N.Id AND Credit IS NOT NULL ORDER BY [Date] DESC) AS [LatestPaymentDate],
+        (SELECT TOP 1 [Date] FROM [Notification].[Transaction] WHERE NotificationId = N.Id AND Debit IS NOT NULL ORDER BY [Date] DESC) AS [LatestRefundDate],
+		(SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
+          FROM [Notification].[Transaction] T2
+          WHERE T2.NotificationId = N.Id
+		  ORDER BY [Date] ASC
+          FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)') AS Comments
+    FROM [Notification].[Transaction] T
+    INNER JOIN [Notification].[Notification] N ON N.Id = T.NotificationId
+    GROUP BY N.Id, N.NotificationNumber
+
+    UNION ALL
+
+    SELECT 
+        N.Id AS [NotificationId],
+        REPLACE(N.NotificationNumber, ' ', '') AS NotificationNumber,
+        SUM(T.Credit) AS TotalPaid,
+        SUM(T.Debit) AS TotalRefunded,
+        (SELECT TOP 1 [Date] FROM [ImportNotification].[Transaction] WHERE NotificationId = N.Id AND Credit IS NOT NULL ORDER BY [Date] DESC) AS [LatestPaymentDate],
+        (SELECT TOP 1 [Date] FROM [ImportNotification].[Transaction] WHERE NotificationId = N.Id AND Debit IS NOT NULL ORDER BY [Date] DESC) AS [LatestRefundDate],
+		(SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
+          FROM [ImportNotification].[Transaction] T2
+          WHERE T2.NotificationId = N.Id
+		  ORDER BY [Date] ASC
+          FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)') AS Comments
+    FROM [ImportNotification].[Transaction] T
+    INNER JOIN [ImportNotification].[Notification] N ON N.Id = T.NotificationId
+    GROUP BY N.Id, N.NotificationNumber
+GO

--- a/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-144700-alter-reports-finance-view.sql
+++ b/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-144700-alter-reports-finance-view.sql
@@ -37,7 +37,7 @@ AS
         N.CompetentAuthorityId,
         NA.ReceivedDate,
         CASE WHEN FC.IsInterim IS NULL THEN InS.IsInterim ELSE FC.IsInterim END AS IsInterim,
-		P.Comments AS PaymentComments
+        P.Comments AS PaymentComments
     FROM [Reports].[NotificationOrganisations] NO
     INNER JOIN [Reports].[NotificationAssessment] NA ON NO.Id = NA.NotificationId
     INNER JOIN [Reports].[Notification] N ON NO.Id = N.Id

--- a/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-144700-alter-reports-finance-view.sql
+++ b/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190218-144700-alter-reports-finance-view.sql
@@ -1,0 +1,51 @@
+IF OBJECT_ID('[Reports].[Finance]') IS NULL
+    EXEC('CREATE VIEW [Reports].[Finance] AS SELECT 1 AS [NOTHING];')
+GO
+
+ALTER VIEW [Reports].[Finance]
+AS
+    SELECT 
+        NO.NotificationNumber,
+        CASE WHEN IU.Id IS NULL THEN 'External' ELSE 'Internal' END AS CreatedBy,
+        NO.Exporter AS [Notifier],
+        NO.ExporterAddress AS [NotifierAddress],
+        NO.ExporterPostalCode AS [NotifierPostalCode],
+        NO.Importer AS [Consignee],
+        NO.ImporterAddress AS [ConsigneeAddress],
+        NO.ImporterPostalCode AS [ConsigneePostalCode],
+        NO.Facility,
+        NO.FacilityAddress,
+        NO.FacilityPostalCode,
+        NA.PaymentReceivedDate,
+        N.Charge AS [TotalBillable],
+        P.TotalPaid,
+        P.LatestPaymentDate,
+        CASE WHEN P.TotalPaid IS NULL THEN NULL ELSE (SELECT PotentialRefund FROM [Reports].[PricingInfo](N.Id)) END AS AmountToRefund,
+        P.TotalRefunded,
+        P.LatestRefundDate,
+        N.NumberOfShipments AS [IntendedNumberOfShipments],
+        N.IntendedQuantity,
+        N.Units,
+        (SELECT COUNT(MovementId) FROM [Reports].[Movements] WHERE NotificationId = NO.Id) AS [TotalShipmentsMade],
+        N.ImportOrExport,
+        N.Type AS NotificationType,
+        CAST(N.Preconsented AS BIT) AS [Preconsented],
+        CAST(NO.HasMultipleFacilities AS BIT) AS [HasMultipleFacilities],
+        NA.ConsentFrom,
+        NA.ConsentTo,
+        NA.Status,
+        N.CompetentAuthorityId,
+        NA.ReceivedDate,
+        CASE WHEN FC.IsInterim IS NULL THEN InS.IsInterim ELSE FC.IsInterim END AS IsInterim,
+		P.Comments AS PaymentComments
+    FROM [Reports].[NotificationOrganisations] NO
+    INNER JOIN [Reports].[NotificationAssessment] NA ON NO.Id = NA.NotificationId
+    INNER JOIN [Reports].[Notification] N ON NO.Id = N.Id
+    LEFT JOIN [Reports].[Payments] P ON NO.Id = P.NotificationId
+    LEFT JOIN [Person].[InternalUser] IU ON N.[UserId] = IU.[UserId]
+    LEFT JOIN [Notification].[FacilityCollection] FC ON NO.Id = FC.NotificationId
+    LEFT JOIN [ImportNotification].[InterimStatus] InS ON NO.Id = InS.ImportNotificationId
+    WHERE 
+        (NA.[ExportStatusId] IS NULL OR NA.[ExportStatusId] <> 1 OR (NA.[ExportStatusId] = 1 AND IU.[UserId] IS NOT NULL))
+        AND (NA.[ImportStatusId] IS NULL OR NA.[ImportStatusId] > 1)
+GO

--- a/src/EA.Iws.Domain/Reports/Finance.cs
+++ b/src/EA.Iws.Domain/Reports/Finance.cs
@@ -65,5 +65,7 @@
         public string Status { get; protected set; }
 
         public bool? IsInterim { get; protected set; }
+
+        public string PaymentComments { get; protected set; }
     }
 }

--- a/src/EA.Iws.RequestHandlers/Mappings/Reports/FinanceMap.cs
+++ b/src/EA.Iws.RequestHandlers/Mappings/Reports/FinanceMap.cs
@@ -31,6 +31,7 @@
                 Notifier = source.Notifier,
                 NotifierAddress = source.NotifierAddress,
                 NotifierPostalCode = source.NotifierPostalCode,
+                PaymentComments = source.PaymentComments,
                 PaymentReceivedDate = source.PaymentReceivedDate,
                 ReceivedDate = source.ReceivedDate,
                 TotalBillable = source.TotalBillable,


### PR DESCRIPTION
PBI 66613: Payment comments need to be presented on Finance Report.

I'd like to specifically highlight the following code (found in alter-reports-payments-view.sql):

(SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
          FROM [Notification].[Transaction] T2
          WHERE T2.NotificationId = N.Id
		  ORDER BY [Date] ASC
          FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)') AS Comments

The role of this code is as follows:
1. Remove leading/trailing white space from each comment.
2. Suffix each comment with a full stop and a space. The logic takes into account whether there is already a full stop and only adds the space if this is false
3. Order the comments by date ascending.
4. Take all payment comments for a notification and concatenate them together into one string (NOTE: this would have been more straightforward to code in SQL Server 2017 as we'd be able to use the STRING_AGG function, rather than relying on a sub-query).