### PR TITLE
Update validation for checking dates for recovery/disposal.

### DIFF
--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryAlreadyRecoveredRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryAlreadyRecoveredRule.cs
@@ -24,25 +24,27 @@
 
         public async Task<ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>> GetResult(List<ReceiptRecoveryMovement> movements, Guid notificationId)
         {
-            var actualMovements = await movementRepo.GetAllMovements(notificationId);
+            var actualMovements = (await movementRepo.GetAllMovements(notificationId)).ToList();
             var notification = await notificationRepo.GetById(notificationId);
+            var shipments = new List<int>();
 
-            List<int> shipments = new List<int>();
-            MessageLevel result = MessageLevel.Success;
+            var validMovements =
+                movements.Where(p => !p.MissingRecoveredDisposedDate && p.RecoveredDisposedDate.HasValue);
 
-            foreach (var movement in movements.Where(p => p.RecoveredDisposedDate.HasValue))
+            foreach (var movement in validMovements)
             {
                 var actualMovement = actualMovements.FirstOrDefault(p => p.Number == movement.ShipmentNumber);
 
                 if (actualMovement != null && actualMovement.Status == MovementStatus.Completed)
                 {
-                    result = MessageLevel.Error;
                     shipments.Add(movement.ShipmentNumber.GetValueOrDefault());
                 }
             }
 
+            var result = shipments.Any() ? MessageLevel.Error : MessageLevel.Success;
             var shipmentNumbers = string.Join(", ", shipments.Distinct());
-            string type = notification.NotificationType == Core.Shared.NotificationType.Disposal ? "disposed" : "recovered";
+
+            var type = notification.NotificationType == NotificationType.Disposal ? "disposed" : "recovered";
             var errorMessage = string.Format(Prsd.Core.Helpers.EnumHelper.GetDisplayName(ReceiptRecoveryContentRules.AlreadyRecievedRecoveredDisposed), shipmentNumbers, type);
 
             return new ReceiptRecoveryContentRuleResult<ReceiptRecoveryContentRules>(ReceiptRecoveryContentRules.AlreadyRecievedRecoveredDisposed, result, errorMessage, shipments.DefaultIfEmpty(0).Min());

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryRecoveryOnlyRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryRecoveryOnlyRule.cs
@@ -37,7 +37,10 @@
             {
                 var actualMovement = actualMovements.FirstOrDefault(p => p.Number == movement.ShipmentNumber);
 
-                if (actualMovement != null && actualMovement.Status != MovementStatus.Received)
+                if (actualMovement != null && 
+                    actualMovement.Status != MovementStatus.Received &&
+                    //Exclude Completed ones as these will be picked up by Already Recovered Rule
+                    actualMovement.Status != MovementStatus.Completed)
                 {
                     shipments.Add(movement.ShipmentNumber.GetValueOrDefault());
                 }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryShipmentMustBePrenotifiedRule.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkReceiptRecovery/ReceiptRecoveryShipmentMustBePrenotifiedRule.cs
@@ -39,6 +39,7 @@
                 var actualMovement = actualMovements.FirstOrDefault(p => p.Number == movement.ShipmentNumber);
 
                 if (actualMovement != null &&
+                    //Exclude these statuses as these will be picked up by Already Received and Already Recovered rules.
                     actualMovement.Status != MovementStatus.Received &&
                     actualMovement.Status != MovementStatus.Completed)
                 {


### PR DESCRIPTION
Task 67542.

Validation rule for Recovery Only to exclude any shipment that is already in Completed status (Recovered/Disposed). Reason for this is because there is already a separate rule that will specifically look at shipments that are in Completed status.