### PR TITLE
Data file validation - message update

### DIFF
--- a/src/EA.Iws.Core/Movement/BulkUpload/BulkFileRules.cs
+++ b/src/EA.Iws.Core/Movement/BulkUpload/BulkFileRules.cs
@@ -10,9 +10,9 @@
         FileSize,
         [Display(Name = "We've detected a virus in the file you uploaded.")]
         Virus,
-        [Display(Name = "Unable to read the file, format is invalid.")]
+        [Display(Name = "Unable to read the data, the column format is invalid.")]
         FileParse,
-        [Display(Name = "The file does not contain any data.")]
+        [Display(Name = "The file must contain valid data.")]
         EmptyData,
         [Display(Name = "The file type is unsupported: please upload a PDF, image or standard MS Office or Open Office file.")]
         SupportingDocumentFileType

--- a/src/EA.Iws.Web/Infrastructure/BulkUpload/BulkFileValidator.cs
+++ b/src/EA.Iws.Web/Infrastructure/BulkUpload/BulkFileValidator.cs
@@ -37,7 +37,9 @@
                 await GetVirusScan(file)
             };
 
-            if (type != BulkFileType.SupportingDocument)
+            if (type != BulkFileType.SupportingDocument &&
+                // Only run this rule if all rules above have passed.
+                rules.All(r => r.MessageLevel == MessageLevel.Success))
             {
                 rules.Add(await GetFileParse(file));
 


### PR DESCRIPTION
PBI 65554 (prenote) and 66359 (r/r).

Update the validation message for not being able to parse the data as well as when the data file is empty. Ensure these rules are only executed when the file type, size and virus checks have passed.

See PBI A/C for updates.

NOTE - both prenote and r/r uses `IBulkFileValidator` but fixing this in `release/bulk-prenote` then will push this out to `develop`.