### PR TITLE
Ignore case when parsing into enum for packaging types and quantity.

### DIFF
--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/PackagingTypesDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/PackagingTypesDataRowMap.cs
@@ -24,7 +24,7 @@
                 {
                     PackagingType parsed;
 
-                    if (Enum.TryParse(packaging, out parsed) &&
+                    if (Enum.TryParse(packaging, true, out parsed) &&
                         Enum.IsDefined(typeof(PackagingType), parsed))
                     {
                         result.Add(parsed);

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ShipmentQuantityUnitDataRowMap.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Mappings/ShipmentQuantityUnitDataRowMap.cs
@@ -20,7 +20,7 @@
                 // Small 'hack' when this is supplied as the unit.
                 data = data == "m3" ? "CubicMetres" : data;
 
-                if (Enum.TryParse(data, out parsed) &&
+                if (Enum.TryParse(data, true, out parsed) &&
                     Enum.IsDefined(typeof(ShipmentQuantityUnits), parsed))
                 {
                     result = parsed;


### PR DESCRIPTION
BUG 67634.

Thankfully `Enum.Tryparse` has an overload method to do this by supplying a third `boolean` parameter.