### PR TITLE
Fix issue with checking customs office selections for progress tracker.

### DIFF
--- a/src/EA.Iws.RequestHandlers/Notification/NotificationProgressService.cs
+++ b/src/EA.Iws.RequestHandlers/Notification/NotificationProgressService.cs
@@ -165,9 +165,11 @@
                 progress.HasCustomsOffice = false;
             }
 
-            bool? isEntryCustomsOfficeRequired = progressResult.CustomsOffices.First().IsEntryCustomsOfficeRequired;
-            bool? isExitCustomsOfficeRequired = progressResult.CustomsOffices.First().IsExitCustomsOfficeRequired;
-            progress.HasCustomsOfficeSelections = isEntryCustomsOfficeRequired != null && isExitCustomsOfficeRequired != null;
+            progress.HasCustomsOfficeSelections = progressResult.CustomsOffices.Any() &&
+                                                  (progressResult.CustomsOffices.First().IsEntryCustomsOfficeRequired !=
+                                                   null &&
+                                                   progressResult.CustomsOffices.First().IsExitCustomsOfficeRequired !=
+                                                   null);
 
             return progress.HasStateOfExport
                 && progress.HasStateOfImport


### PR DESCRIPTION
BUG 67694 - unable to open any notification application.

Currently failing on `.First()` if there aren't any items in the `CustomOffices` collection and so it's throwing an exception.

#805 - original change.