### PR TITLE
Feature/decision required by date editable

### DIFF
--- a/src/EA.Iws.Core/Admin/KeyDates/KeyDatesOverrideData.cs
+++ b/src/EA.Iws.Core/Admin/KeyDates/KeyDatesOverrideData.cs
@@ -16,6 +16,8 @@
 
         public DateTime? AcknowledgedDate { get; set; }
 
+        public DateTime? DecisionRequiredByDate { get; set; }
+
         public DateTime? WithdrawnDate { get; set; }
 
         public DateTime? ObjectedDate { get; set; }

--- a/src/EA.Iws.DataAccess/Repositories/Imports/KeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/KeyDatesOverrideRepository.cs
@@ -65,5 +65,13 @@
                 new SqlParameter("@ConsentValidFromDate", (object)data.ConsentValidFromDate ?? DBNull.Value),
                 new SqlParameter("@ConsentValidToDate", (object)data.ConsentValidToDate ?? DBNull.Value));
         }
+
+        public async Task SetDecisionRequiredByDateForNotification(Guid notificationAssessmentId, DateTime? decisionRequiredByDate)
+        {
+            await context.Database.ExecuteSqlCommandAsync(@"
+                UPDATE [ImportNotification].[NotificationDates] SET [DecisionRequiredByDate] = @DecisionRequiredByDate WHERE [NotificationAssessmentId] = @NotificationAssessmentId",
+                new SqlParameter("@NotificationAssessmentId", notificationAssessmentId),
+                new SqlParameter("@DecisionRequiredByDate", decisionRequiredByDate));
+        }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
@@ -25,6 +25,7 @@
                     D.[CompleteDate],
                     D.[TransmittedDate],
                     D.[AcknowledgedDate],
+                    D.[DecisionRequiredByDate],
                     D.[WithdrawnDate],
                     D.[ObjectedDate],
                     D.[ConsentedDate],
@@ -65,5 +66,13 @@
                 new SqlParameter("@ConsentValidFromDate", (object)data.ConsentValidFromDate ?? DBNull.Value),
                 new SqlParameter("@ConsentValidToDate", (object)data.ConsentValidToDate ?? DBNull.Value));
         }
+
+        public async Task SetDecisionRequiredByDateForNotification(Guid notificationAssessmentId, DateTime? decisionRequiredByDate)
+        {
+            await context.Database.ExecuteSqlCommandAsync(@"
+                UPDATE [Notification].[NotificationDates] SET [DecisionRequiredByDate] = @DecisionRequiredByDate WHERE [NotificationAssessmentId] = @NotificationAssessmentId",
+                new SqlParameter("@NotificationAssessmentId", notificationAssessmentId),
+                new SqlParameter("@DecisionRequiredByDate", decisionRequiredByDate));
+    }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
@@ -25,7 +25,6 @@
                     D.[CompleteDate],
                     D.[TransmittedDate],
                     D.[AcknowledgedDate],
-                    D.[DecisionRequiredByDate],
                     D.[WithdrawnDate],
                     D.[ObjectedDate],
                     D.[ConsentedDate],

--- a/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/KeyDatesOverrideRepository.cs
@@ -72,6 +72,6 @@
                 UPDATE [Notification].[NotificationDates] SET [DecisionRequiredByDate] = @DecisionRequiredByDate WHERE [NotificationAssessmentId] = @NotificationAssessmentId",
                 new SqlParameter("@NotificationAssessmentId", notificationAssessmentId),
                 new SqlParameter("@DecisionRequiredByDate", decisionRequiredByDate));
-    }
+        }
     }
 }

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -94,6 +94,7 @@
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190131-141400-add-bulk-prenote-draft.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190211-150500-update-draft.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint5\20190208-092800-update-movement-carrier-keys.sql" />
+    <Content Include="scripts\Update\0005-Beta\Sprint6\20190220-124500-alter-notificationdates.sql" />
     <Content Include="scripts\Update\0005-Beta\Sprint6\20190214-133900-add-entryExitCustomsTable.sql" />
     <Content Include="unindexed-foreign-keys.sql" />
     <Content Include="scripts\Everytime\01-Functions\0003-Reports-PricingInfo.sql" />

--- a/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190220-124500-alter-notificationdates.sql
+++ b/src/EA.Iws.Database/scripts/Update/0005-Beta/Sprint6/20190220-124500-alter-notificationdates.sql
@@ -1,0 +1,7 @@
+ALTER TABLE [ImportNotification].[NotificationDates]
+ADD [DecisionRequiredByDate] DATE NULL;
+GO
+
+ALTER TABLE [Notification].[NotificationDates]
+ADD [DecisionRequiredByDate] DATE NULL;
+GO

--- a/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
+++ b/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
@@ -155,6 +155,7 @@
     <Compile Include="NotificationApplication\NotificationWasteGenerationProcessTests.cs" />
     <Compile Include="NotificationApplication\NotificationWasteTypeTests.cs" />
     <Compile Include="NotificationAssessment\CompleteNotificationTests.cs" />
+    <Compile Include="NotificationAssessment\DecisionRequiredByTests.cs" />
     <Compile Include="NotificationAssessment\FinancialGuaranteeDecisionRequiredTests.cs" />
     <Compile Include="NotificationAssessment\NotificationAssessmentEditableTests.cs" />
     <Compile Include="NotificationAssessment\NotificationAssessmentStatusTests.cs" />

--- a/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
+++ b/src/EA.Iws.Domain.Tests.Unit/EA.Iws.Domain.Tests.Unit.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ImportMovement\ImportMovementFactoryTests.cs" />
     <Compile Include="ImportMovement\ReceiveImportMovementTests.cs" />
     <Compile Include="ImportMovement\RejectImportMovementTests.cs" />
+    <Compile Include="ImportNotificationAssessment\DecisionRequiredByTests.cs" />
     <Compile Include="ImportNotificationAssessment\ImportNotificationAssessmentTests.cs" />
     <Compile Include="ImportNotificationAssessment\Transactions\ImportNotificationTransactionCalculatorTests.cs" />
     <Compile Include="ImportNotificationAssessment\Transactions\ImportPaymentTransactionTests.cs" />

--- a/src/EA.Iws.Domain.Tests.Unit/ImportNotificationAssessment/DecisionRequiredByTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/ImportNotificationAssessment/DecisionRequiredByTests.cs
@@ -1,0 +1,118 @@
+﻿namespace EA.Iws.Domain.Tests.Unit.ImportNotificationAssessment
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Core.Notification;
+    using Core.Shared;
+    using Domain.ImportNotification;
+    using Domain.ImportNotificationAssessment;
+    using Domain.ImportNotificationAssessment.Decision;
+    using FakeItEasy;
+    using Xunit;
+
+    public class DecisionRequiredByTests
+    {
+        private readonly IDecisionRequiredByCalculator decisionRequiredByCalculator;
+        private readonly IFacilityRepository facilityRepository;
+        private readonly IImportNotificationRepository importNotificationRepository;
+        private readonly DecisionRequiredBy decisionRequiredBy;
+        private readonly ImportNotificationAssessment assessment;
+        private readonly DateTime? decisionRequiredByDateWhenPopulatedInDB;
+        private readonly DateTime? decisionRequiredByDateWhenNotPopulatedInDB;
+        private readonly DateTime? acknowledgedDateWhenHasValue;
+        private readonly DateTime? acknowledgedDateWhenHasNoValue;
+        private readonly DateTime? decisionRequiredByDateWhenAcknowledgeDateHasNoValue;
+        private readonly DateTime? decisionRequiredByDateWhenCalculated;
+        private readonly Guid notificationId;
+        private readonly UKCompetentAuthority competentAuthority;
+
+        public DecisionRequiredByTests()
+        {
+            notificationId = new Guid();
+            competentAuthority = UKCompetentAuthority.England;
+
+            decisionRequiredByCalculator = A.Fake<IDecisionRequiredByCalculator>();
+            facilityRepository = A.Fake<IFacilityRepository>();
+            importNotificationRepository = A.Fake<IImportNotificationRepository>();
+            assessment = new ImportNotificationAssessment(notificationId);
+
+            decisionRequiredBy = new DecisionRequiredBy(importNotificationRepository, facilityRepository, decisionRequiredByCalculator);
+
+            decisionRequiredByDateWhenPopulatedInDB = new DateTime(2019, 1, 1);
+            decisionRequiredByDateWhenNotPopulatedInDB = null;
+            acknowledgedDateWhenHasValue = new DateTime(2019, 2, 2);
+            acknowledgedDateWhenHasNoValue = null;
+            decisionRequiredByDateWhenAcknowledgeDateHasNoValue = null;
+            decisionRequiredByDateWhenCalculated = new DateTime(2019, 3, 3);
+        }
+
+        [Fact]
+        public async Task DecisionRequiredByDate_IsDateRetrivedFromDatabase()
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenPopulatedInDB;
+
+            var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenPopulatedInDB, decisionRequiredByDate);
+        }
+
+        [Fact]
+        public async Task DecisionRequiredByDate_AcknowledgedDateHasNoValue()
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasNoValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenNotPopulatedInDB;
+
+            var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenAcknowledgeDateHasNoValue, decisionRequiredByDate);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DecisionRequiredByDate_DateCalculated(bool areFacilitiesPreconsented)
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenNotPopulatedInDB;
+
+            A.CallTo(() => importNotificationRepository.Get(notificationId))
+                .Returns(GetImportNotificationTestData());
+
+            A.CallTo(() => facilityRepository.GetByNotificationId(notificationId))
+                .Returns(GetFacilityCollectionTestData(areFacilitiesPreconsented));
+
+            A.CallTo(() => decisionRequiredByCalculator.Get(areFacilitiesPreconsented, assessment.Dates.AcknowledgedDate.Value, competentAuthority))
+                .Returns(decisionRequiredByDateWhenCalculated.Value);
+
+           var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenCalculated, decisionRequiredByDate);
+        }
+
+        private ImportNotification GetImportNotificationTestData()
+        {
+            var notificationType = NotificationType.Recovery;
+            var notificationNumber = "1";
+
+            return new ImportNotification(notificationType, competentAuthority, notificationNumber);
+        }
+
+        private FacilityCollection GetFacilityCollectionTestData(bool areFacilitiesPreconsented)
+        {
+            return new FacilityCollection(notificationId, GetFacilityListTestData(), areFacilitiesPreconsented);
+        }
+
+        private FacilityList GetFacilityListTestData()
+        {
+            var address = new Address("AddressLine1", "AddressLine2", "TownOrCity", "PostalCode", new Guid());
+            var contact = new Contact("Name", new PhoneNumber("01234567890"), new EmailAddress("email@address.com"));
+            var facilityList = new List<Facility>()
+            {
+                new Facility("businessName", BusinessType.SoleTrader, "RegNumber", address, contact, true)
+            };
+            return new FacilityList(facilityList);
+        }
+    }
+}

--- a/src/EA.Iws.Domain.Tests.Unit/NotificationAssessment/DecisionRequiredByTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/NotificationAssessment/DecisionRequiredByTests.cs
@@ -1,0 +1,99 @@
+﻿namespace EA.Iws.Domain.Tests.Unit.NotificationAssessment
+{
+    using System;
+    using System.Threading.Tasks;
+    using Core.Notification;
+    using Core.Shared;
+    using Domain.NotificationApplication;
+    using Domain.NotificationAssessment;
+    using FakeItEasy;
+    using Xunit;
+
+    public class DecisionRequiredByTests
+    {
+        private readonly IDecisionRequiredByCalculator decisionRequiredByCalculator;
+        private readonly IFacilityRepository facilityRepository;
+        private readonly DecisionRequiredBy decisionRequiredBy;
+        private readonly NotificationApplication application;
+        private readonly NotificationAssessment assessment;
+        private readonly DateTime? decisionRequiredByDateWhenPopulatedInDB;
+        private readonly DateTime? decisionRequiredByDateWhenNotPopulatedInDB;
+        private readonly DateTime? acknowledgedDateWhenHasValue;
+        private readonly DateTime? acknowledgedDateWhenHasNoValue;
+        private readonly DateTime? decisionRequiredByDateWhenAcknowledgeDateHasNoValue;
+        private readonly DateTime? decisionRequiredByDateWhenCalculated;
+
+        public DecisionRequiredByTests()
+        {
+            var applicationId = new Guid();
+            var userId = new Guid();
+            var notificationType = NotificationType.Recovery;
+            var competentAuthority = UKCompetentAuthority.England;
+            var notificationNumber = 1;
+
+            decisionRequiredByCalculator = A.Fake<IDecisionRequiredByCalculator>();
+            facilityRepository = A.Fake<IFacilityRepository>();
+            assessment = new NotificationAssessment(applicationId);
+            application = new NotificationApplication(userId, notificationType, competentAuthority, notificationNumber);
+
+            decisionRequiredBy = new DecisionRequiredBy(decisionRequiredByCalculator, facilityRepository);
+
+            decisionRequiredByDateWhenPopulatedInDB = new DateTime(2019, 1, 1);
+            decisionRequiredByDateWhenNotPopulatedInDB = null;
+            acknowledgedDateWhenHasValue = new DateTime(2019, 2, 2);
+            acknowledgedDateWhenHasNoValue = null;
+            decisionRequiredByDateWhenAcknowledgeDateHasNoValue = null;
+            decisionRequiredByDateWhenCalculated = new DateTime(2019, 3, 3);
+        }
+
+        [Fact]
+        public async Task DecisionRequiredByDate_IsDateRetrivedFromDatabase()
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenPopulatedInDB;
+
+            var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(application, assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenPopulatedInDB, decisionRequiredByDate);
+        }
+
+        [Fact]
+        public async Task DecisionRequiredByDate_AcknowledgedDateHasNoValue()
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasNoValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenNotPopulatedInDB;
+
+            var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(application, assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenAcknowledgeDateHasNoValue, decisionRequiredByDate);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DecisionRequiredByDate_DateCalculated(bool areFacilitiesPreconsented)
+        {
+            assessment.Dates.AcknowledgedDate = acknowledgedDateWhenHasValue;
+            assessment.Dates.DecisionRequiredByDate = decisionRequiredByDateWhenNotPopulatedInDB;
+
+            A.CallTo(() => facilityRepository.GetByNotificationId(application.Id))
+                .Returns(GetFacilityCollectionTestData(areFacilitiesPreconsented));
+
+            A.CallTo(() => decisionRequiredByCalculator.Get(areFacilitiesPreconsented, assessment.Dates.AcknowledgedDate.Value, application.CompetentAuthority))
+                .Returns(decisionRequiredByDateWhenCalculated.Value);
+
+           var decisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(application, assessment);
+
+            Assert.Equal(decisionRequiredByDateWhenCalculated, decisionRequiredByDate);
+        }
+
+        private FacilityCollection GetFacilityCollectionTestData(bool areFacilitiesPreconsented)
+        {
+            var notificationId = new Guid();
+            return new FacilityCollection(notificationId)
+            {
+                AllFacilitiesPreconsented = areFacilitiesPreconsented
+            };
+        }
+    }
+}

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/Decision/DecisionRequiredBy.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/Decision/DecisionRequiredBy.cs
@@ -26,6 +26,11 @@
         {
             Guard.ArgumentNotNull(() => notificationAssessment, notificationAssessment);
 
+            if (notificationAssessment.Dates.DecisionRequiredByDate != null)
+            {
+                return notificationAssessment.Dates.DecisionRequiredByDate;
+            }
+
             if (!notificationAssessment.Dates.AcknowledgedDate.HasValue)
             {
                 return null;

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/IKeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/IKeyDatesOverrideRepository.cs
@@ -9,5 +9,7 @@
         Task<KeyDatesOverrideData> GetKeyDatesForNotification(Guid notificationId);
 
         Task SetKeyDatesForNotification(KeyDatesOverrideData data);
+
+        Task SetDecisionRequiredByDateForNotification(Guid notificationAssessmentId, DateTime? decisionRequiredByDate);
     }
 }

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/ImportNotificationDates.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/ImportNotificationDates.cs
@@ -17,6 +17,8 @@
 
         public DateTime? AcknowledgedDate { get; internal set; }
 
+        public DateTime? DecisionRequiredByDate { get; internal set; }
+
         public DateTime? ConsentedDate { get; internal set; }
 
         public DateTime? ConsentWithdrawnDate { get; internal set; }

--- a/src/EA.Iws.Domain/NotificationAssessment/DecisionRequiredBy.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/DecisionRequiredBy.cs
@@ -24,6 +24,11 @@
             Guard.ArgumentNotNull(() => notificationApplication, notificationApplication);
             Guard.ArgumentNotNull(() => notificationAssessment, notificationAssessment);
 
+            if (notificationAssessment.Dates.DecisionRequiredByDate != null)
+            {
+                return notificationAssessment.Dates.DecisionRequiredByDate;
+            }
+
             if (!notificationAssessment.Dates.AcknowledgedDate.HasValue)
             {
                 return null;

--- a/src/EA.Iws.Domain/NotificationAssessment/IKeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/IKeyDatesOverrideRepository.cs
@@ -10,6 +10,6 @@
 
         Task SetKeyDatesForNotification(KeyDatesOverrideData data);
 
-        Task SetDecisionRequiredByDateForNotification(Guid notificationId, DateTime? decisionRequiredByDate);
+        Task SetDecisionRequiredByDateForNotification(Guid notificationAssessmentId, DateTime? decisionRequiredByDate);
     }
 }

--- a/src/EA.Iws.Domain/NotificationAssessment/IKeyDatesOverrideRepository.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/IKeyDatesOverrideRepository.cs
@@ -9,5 +9,7 @@
         Task<KeyDatesOverrideData> GetKeyDatesForNotification(Guid notificationId);
 
         Task SetKeyDatesForNotification(KeyDatesOverrideData data);
+
+        Task SetDecisionRequiredByDateForNotification(Guid notificationId, DateTime? decisionRequiredByDate);
     }
 }

--- a/src/EA.Iws.Domain/NotificationAssessment/NotificationDates.cs
+++ b/src/EA.Iws.Domain/NotificationAssessment/NotificationDates.cs
@@ -21,6 +21,8 @@ namespace EA.Iws.Domain.NotificationAssessment
 
         public DateTime? AcknowledgedDate { get; internal set; }
 
+        public DateTime? DecisionRequiredByDate { get; internal set; }
+
         public string NameOfOfficer { get; internal set; }
 
         public DateTime? WithdrawnDate { get; internal set; }

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/GetExportKeyDatesOverrideDataHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/GetExportKeyDatesOverrideDataHandler.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using Core.Admin.KeyDates;
+    using Domain.NotificationApplication;
     using Domain.NotificationAssessment;
     using Prsd.Core.Mediator;
     using Requests.Admin.KeyDates;
@@ -10,15 +11,30 @@
         IRequestHandler<GetExportKeyDatesOverrideData, KeyDatesOverrideData>
     {
         private readonly IKeyDatesOverrideRepository repository;
+        private readonly INotificationAssessmentRepository assessmentRepository;
+        private readonly INotificationApplicationRepository applicationRepository;
+        private readonly DecisionRequiredBy decisionRequiredBy;
 
-        public GetExportKeyDatesOverrideDataHandler(IKeyDatesOverrideRepository repository)
+        public GetExportKeyDatesOverrideDataHandler(IKeyDatesOverrideRepository repository,
+            INotificationAssessmentRepository assessmentRepository,
+            INotificationApplicationRepository applicationRepository,
+            DecisionRequiredBy decisionRequiredBy)
         {
             this.repository = repository;
+            this.assessmentRepository = assessmentRepository;
+            this.applicationRepository = applicationRepository;
+            this.decisionRequiredBy = decisionRequiredBy;
         }
 
         public async Task<KeyDatesOverrideData> HandleAsync(GetExportKeyDatesOverrideData message)
         {
-            return await repository.GetKeyDatesForNotification(message.NotificationId);
+            var assessment = await assessmentRepository.GetByNotificationId(message.NotificationId);
+            var notification = await applicationRepository.GetById(message.NotificationId);
+            var keyDates = await repository.GetKeyDatesForNotification(message.NotificationId);
+
+            keyDates.DecisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(notification, assessment);
+
+            return keyDates;
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
@@ -1,6 +1,5 @@
 ﻿namespace EA.Iws.RequestHandlers.Admin.KeyDates
 {
-    using System;
     using System.Threading.Tasks;
     using Domain.NotificationApplication;
     using Domain.NotificationAssessment;

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
@@ -27,12 +27,11 @@
 
         public async Task<Unit> HandleAsync(SetExportKeyDatesOverride message)
         {
-            // Do you need to use currentDecisionRequiredByDate, assessment.Dates.DecisionRequiredByDate or a combination of both
             var assessment = await assessmentRepository.GetByNotificationId(message.Data.NotificationId);
             var notification = await applicationRepository.GetById(message.Data.NotificationId);
             var currentDecisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(notification, assessment);
 
-            if (assessment.Dates.DecisionRequiredByDate != message.Data.DecisionRequiredByDate)
+            if (currentDecisionRequiredByDate != message.Data.DecisionRequiredByDate)
             {
                 await repository.SetDecisionRequiredByDateForNotification(assessment.Id, message.Data.DecisionRequiredByDate);
             }

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetExportKeyDatesOverrideHandler.cs
@@ -1,6 +1,8 @@
 ﻿namespace EA.Iws.RequestHandlers.Admin.KeyDates
 {
+    using System;
     using System.Threading.Tasks;
+    using Domain.NotificationApplication;
     using Domain.NotificationAssessment;
     using Prsd.Core.Mediator;
     using Requests.Admin.KeyDates;
@@ -8,15 +10,35 @@
     internal class SetExportKeyDatesOverrideHandler : IRequestHandler<SetExportKeyDatesOverride, Unit>
     {
         private readonly IKeyDatesOverrideRepository repository;
+        private readonly INotificationAssessmentRepository assessmentRepository;
+        private readonly INotificationApplicationRepository applicationRepository;
+        private readonly DecisionRequiredBy decisionRequiredBy;
 
-        public SetExportKeyDatesOverrideHandler(IKeyDatesOverrideRepository repository)
+        public SetExportKeyDatesOverrideHandler(IKeyDatesOverrideRepository repository,
+            INotificationAssessmentRepository assessmentRepository,
+            INotificationApplicationRepository applicationRepository,
+            DecisionRequiredBy decisionRequiredBy)
         {
             this.repository = repository;
+            this.assessmentRepository = assessmentRepository;
+            this.applicationRepository = applicationRepository;
+            this.decisionRequiredBy = decisionRequiredBy;
         }
 
         public async Task<Unit> HandleAsync(SetExportKeyDatesOverride message)
         {
+            // Do you need to use currentDecisionRequiredByDate, assessment.Dates.DecisionRequiredByDate or a combination of both
+            var assessment = await assessmentRepository.GetByNotificationId(message.Data.NotificationId);
+            var notification = await applicationRepository.GetById(message.Data.NotificationId);
+            var currentDecisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(notification, assessment);
+
+            if (assessment.Dates.DecisionRequiredByDate != message.Data.DecisionRequiredByDate)
+            {
+                await repository.SetDecisionRequiredByDateForNotification(assessment.Id, message.Data.DecisionRequiredByDate);
+            }
+
             await repository.SetKeyDatesForNotification(message.Data);
+
             return Unit.Value;
         }
     }

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetImportKeyDatesOverrideHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetImportKeyDatesOverrideHandler.cs
@@ -18,6 +18,7 @@
             DecisionRequiredBy decisionRequiredBy)
         {
             this.repository = repository;
+            this.assessmentRepository = assessmentRepository;
             this.decisionRequiredBy = decisionRequiredBy;
         }
 

--- a/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetImportKeyDatesOverrideHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/KeyDates/SetImportKeyDatesOverrideHandler.cs
@@ -1,22 +1,38 @@
 ﻿namespace EA.Iws.RequestHandlers.Admin.KeyDates
 {
     using System.Threading.Tasks;
+    using Domain.ImportNotification;
     using Domain.ImportNotificationAssessment;
+    using Domain.ImportNotificationAssessment.Decision;
     using Prsd.Core.Mediator;
     using Requests.Admin.KeyDates;
 
     internal class SetimportKeyDatesOverrideHandler : IRequestHandler<SetImportKeyDatesOverride, Unit>
     {
         private readonly IKeyDatesOverrideRepository repository;
+        private readonly IImportNotificationAssessmentRepository assessmentRepository;
+        private readonly DecisionRequiredBy decisionRequiredBy;
 
-        public SetimportKeyDatesOverrideHandler(IKeyDatesOverrideRepository repository)
+        public SetimportKeyDatesOverrideHandler(IKeyDatesOverrideRepository repository,
+            IImportNotificationAssessmentRepository assessmentRepository,
+            DecisionRequiredBy decisionRequiredBy)
         {
             this.repository = repository;
+            this.decisionRequiredBy = decisionRequiredBy;
         }
 
         public async Task<Unit> HandleAsync(SetImportKeyDatesOverride message)
         {
+            var assessment = await assessmentRepository.GetByNotification(message.Data.NotificationId);
+            var currentDecisionRequiredByDate = await decisionRequiredBy.GetDecisionRequiredByDate(assessment);
+
+            if (currentDecisionRequiredByDate != message.Data.DecisionRequiredByDate)
+            {
+                await repository.SetDecisionRequiredByDateForNotification(assessment.Id, message.Data.DecisionRequiredByDate);
+            }
+
             await repository.SetKeyDatesForNotification(message.Data);
+
             return Unit.Value;
         }
     }

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/Controllers/KeyDatesOverrideController.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/Controllers/KeyDatesOverrideController.cs
@@ -46,6 +46,7 @@
                 ConsentedDate = model.ConsentedDate.AsDateTime(),
                 ConsentValidFromDate = model.ConsentValidFromDate.AsDateTime(),
                 ConsentValidToDate = model.ConsentValidToDate.AsDateTime(),
+                DecisionRequiredByDate = model.DecisionRequiredByDate.AsDateTime(),
                 NotificationId = id,
                 NotificationReceivedDate = model.NotificationReceivedDate.AsDateTime(),
                 ObjectedDate = model.ObjectedDate.AsDateTime(),

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
@@ -1,5 +1,6 @@
 ﻿namespace EA.Iws.Web.Areas.AdminExportAssessment.ViewModels.KeyDatesOverride
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
     using Core.Admin.KeyDates;
     using Web.ViewModels.Shared;
@@ -13,6 +14,7 @@
             CompleteDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             TransmittedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             AcknowledgedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
+            DecisionRequiredByDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             WithdrawnDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             ObjectedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             ConsentedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
@@ -27,6 +29,7 @@
             CompleteDate = new OptionalDateInputViewModel(data.CompleteDate, allowPastDates: true, showLabels: false);
             TransmittedDate = new OptionalDateInputViewModel(data.TransmittedDate, allowPastDates: true, showLabels: false);
             AcknowledgedDate = new OptionalDateInputViewModel(data.AcknowledgedDate, allowPastDates: true, showLabels: false);
+            DecisionRequiredByDate = new OptionalDateInputViewModel(data.DecisionRequiredByDate, allowPastDates: true, showLabels: false);
             WithdrawnDate = new OptionalDateInputViewModel(data.WithdrawnDate, allowPastDates: true, showLabels: false);
             ObjectedDate = new OptionalDateInputViewModel(data.ObjectedDate, allowPastDates: true, showLabels: false);
             ConsentedDate = new OptionalDateInputViewModel(data.ConsentedDate, allowPastDates: true, showLabels: false);
@@ -48,6 +51,9 @@
 
         [Display(Name = "AcknowledgedDate", ResourceType = typeof(IndexViewModelResources))]
         public OptionalDateInputViewModel AcknowledgedDate { get; set; }
+
+        [Display(Name = "DecisionRequiredByDate", ResourceType = typeof(IndexViewModelResources))]
+        public OptionalDateInputViewModel DecisionRequiredByDate { get; set; }
 
         [Display(Name = "WithdrawnDate", ResourceType = typeof(IndexViewModelResources))]
         public OptionalDateInputViewModel WithdrawnDate { get; set; }

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
@@ -1,6 +1,5 @@
 ﻿namespace EA.Iws.Web.Areas.AdminExportAssessment.ViewModels.KeyDatesOverride
 {
-    using System;
     using System.ComponentModel.DataAnnotations;
     using Core.Admin.KeyDates;
     using Web.ViewModels.Shared;

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.Designer.cs
@@ -116,6 +116,15 @@ namespace EA.Iws.Web.Areas.AdminExportAssessment.ViewModels.KeyDatesOverride {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Decision required by.
+        /// </summary>
+        public static string DecisionRequiredByDate {
+            get {
+                return ResourceManager.GetString("DecisionRequiredByDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Notification received.
         /// </summary>
         public static string NotificationReceivedDate {

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.resx
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.resx
@@ -147,4 +147,7 @@
   <data name="WithdrawnDate" xml:space="preserve">
     <value>Withdrawn</value>
   </data>
+  <data name="DecisionRequiredByDate" xml:space="preserve">
+    <value>Decision required by</value>
+  </data>
 </root>

--- a/src/EA.Iws.Web/Areas/AdminExportAssessment/Views/KeyDatesOverride/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportAssessment/Views/KeyDatesOverride/Index.cshtml
@@ -57,6 +57,15 @@
             </div>
         }
 
+        @if (Model.DecisionRequiredByDate.IsCompleted)
+        {
+            <div class="form-group @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Day) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Month) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Year)">
+                @Html.Gds().LabelFor(m => m.DecisionRequiredByDate, showOptionalLabel: false)
+                @Html.Gds().ValidationMessageFor(m => m.DecisionRequiredByDate)
+                @Html.EditorFor(m => m.DecisionRequiredByDate)
+            </div>
+        }
+
         @if (Model.WithdrawnDate.IsCompleted)
         {
             <div class="form-group @Html.Gds().FormGroupClass(m => m.WithdrawnDate) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Day) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Month) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Year)">

--- a/src/EA.Iws.Web/Areas/AdminImportAssessment/Controllers/KeyDatesOverrideController.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportAssessment/Controllers/KeyDatesOverrideController.cs
@@ -46,6 +46,7 @@
                 ConsentedDate = model.ConsentedDate.AsDateTime(),
                 ConsentValidFromDate = model.ConsentValidFromDate.AsDateTime(),
                 ConsentValidToDate = model.ConsentValidToDate.AsDateTime(),
+                DecisionRequiredByDate = model.DecisionRequiredByDate.AsDateTime(),
                 NotificationId = id,
                 NotificationReceivedDate = model.NotificationReceivedDate.AsDateTime(),
                 ObjectedDate = model.ObjectedDate.AsDateTime(),

--- a/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModel.cs
@@ -12,6 +12,7 @@
             CommencementDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             CompleteDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             AcknowledgedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
+            DecisionRequiredByDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             WithdrawnDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             ObjectedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
             ConsentedDate = new OptionalDateInputViewModel(allowPastDates: true, showLabels: false);
@@ -25,6 +26,7 @@
             CommencementDate = new OptionalDateInputViewModel(data.CommencementDate, allowPastDates: true, showLabels: false);
             CompleteDate = new OptionalDateInputViewModel(data.CompleteDate, allowPastDates: true, showLabels: false);
             AcknowledgedDate = new OptionalDateInputViewModel(data.AcknowledgedDate, allowPastDates: true, showLabels: false);
+            DecisionRequiredByDate = new OptionalDateInputViewModel(data.DecisionRequiredByDate, allowPastDates: true, showLabels: false);
             WithdrawnDate = new OptionalDateInputViewModel(data.WithdrawnDate, allowPastDates: true, showLabels: false);
             ObjectedDate = new OptionalDateInputViewModel(data.ObjectedDate, allowPastDates: true, showLabels: false);
             ConsentedDate = new OptionalDateInputViewModel(data.ConsentedDate, allowPastDates: true, showLabels: false);
@@ -43,6 +45,9 @@
 
         [Display(Name = "AcknowledgedDate", ResourceType = typeof(IndexViewModelResources))]
         public OptionalDateInputViewModel AcknowledgedDate { get; set; }
+
+        [Display(Name = "DecisionRequiredByDate", ResourceType = typeof(IndexViewModelResources))]
+        public OptionalDateInputViewModel DecisionRequiredByDate { get; set; }
 
         [Display(Name = "WithdrawnDate", ResourceType = typeof(IndexViewModelResources))]
         public OptionalDateInputViewModel WithdrawnDate { get; set; }

--- a/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.Designer.cs
@@ -116,6 +116,15 @@ namespace EA.Iws.Web.Areas.AdminImportAssessment.ViewModels.KeyDatesOverride {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Decision required by.
+        /// </summary>
+        public static string DecisionRequiredByDate {
+            get {
+                return ResourceManager.GetString("DecisionRequiredByDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Notification received.
         /// </summary>
         public static string NotificationReceivedDate {

--- a/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.resx
+++ b/src/EA.Iws.Web/Areas/AdminImportAssessment/ViewModels/KeyDatesOverride/IndexViewModelResources.resx
@@ -144,4 +144,7 @@
   <data name="WithdrawnDate" xml:space="preserve">
     <value>Withdrawn</value>
   </data>
+  <data name="DecisionRequiredByDate" xml:space="preserve">
+    <value>Decision required by</value>
+  </data>
 </root>

--- a/src/EA.Iws.Web/Areas/AdminImportAssessment/Views/KeyDatesOverride/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportAssessment/Views/KeyDatesOverride/Index.cshtml
@@ -48,6 +48,15 @@
             </div>
         }
 
+        @if (Model.DecisionRequiredByDate.IsCompleted)
+        {
+            <div class="form-group @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Day) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Month) @Html.Gds().FormGroupClass(m => m.DecisionRequiredByDate.Year)">
+                @Html.Gds().LabelFor(m => m.DecisionRequiredByDate, showOptionalLabel: false)
+                @Html.Gds().ValidationMessageFor(m => m.DecisionRequiredByDate)
+                @Html.EditorFor(m => m.DecisionRequiredByDate)
+            </div>
+        }
+
         @if (Model.WithdrawnDate.IsCompleted)
         {
             <div class="form-group @Html.Gds().FormGroupClass(m => m.WithdrawnDate) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Day) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Month) @Html.Gds().FormGroupClass(m => m.WithdrawnDate.Year)">


### PR DESCRIPTION
This PR details the work carried out to achieve PBI 66625 which is to allow the decision required by date to be editable.

1. Decision Required By Date was adding to the import and export notification dates tables. Before this PBI the date was solely calculated as and when it was required.
2. The date is only saved to the database when a user deems it necessary to override the calculated value. If the value in the database is null then the calculation will be carried out as per usual. As such it is necessary for the date to only ever be obtained via the DecisionRequiredBy class/es, otherwise they will skip the auto-calculation part of this field. This makes it dangerous to directly select the value from the database. I'm open to discussing alternatives if we aren't happy with this situation.
3. Once the date is saved to the database it is no longer possible to apply the auto-calculation to the field. This behavior has been agreed with Gill.