### PR TITLE
Certain notification statuses are now exempt from the customs office …

### DIFF
--- a/src/EA.Iws.Database/scripts/Everytime/03-StoredProcedures/0001-uspNotificationProgress.sql
+++ b/src/EA.Iws.Database/scripts/Everytime/03-StoredProcedures/0001-uspNotificationProgress.sql
@@ -12,6 +12,7 @@ BEGIN
         N.[Id],
         N.[NotificationType],
         N.[CompetentAuthority],
+		NA.[Status] AS [NotificationStatus],
         N.[NotificationNumber],
         FC.[AllFacilitiesPreconsented] AS [IsPreconsentedRecoveryFacility],
         N.[ReasonForExport],
@@ -89,6 +90,8 @@ BEGIN
         ON N.Id = CC.NotificationId
 
         LEFT JOIN [Notification].[MeansOfTransport] MOT ON N.Id = MOT.NotificationId
+
+		LEFT JOIN [Notification].[NotificationAssessment] NA ON N.Id = NA.NotificationApplicationId
     WHERE
         N.Id = @NotificationId;
 


### PR DESCRIPTION
Notifications can now be exempt from the customs office section progression check. This is because historic records should not be subject to the check as it now exists as they have no selection choices for the Customs Office radio options (populated in the Notification.EntryExitCustomsSelection table).

Gill has stated that it is likely we will change the list of statuses that are exempt. I'll be picking this up with her on Monday.