### PR TITLE
The backToOverview functionality has been added to the customs office…

### DIFF
--- a/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/EntryCustomsOfficeController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/EntryCustomsOfficeController.cs
@@ -25,7 +25,7 @@
         }
 
         [HttpGet]
-        public async Task<ActionResult> Index(Guid id)
+        public async Task<ActionResult> Index(Guid id, bool? backToOverview = null)
         {
             var data = await mediator.SendAsync(new GetEntryCustomsOfficeAddDataByNotificationId(id));
 
@@ -73,7 +73,7 @@
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Index(Guid id, CustomsOfficeViewModel model)
+        public async Task<ActionResult> Index(Guid id, CustomsOfficeViewModel model, bool? backToOverview = null)
         {
             var countries = await mediator.SendAsync(new GetEuropeanUnionCountries());
 
@@ -112,6 +112,10 @@
 
             await mediator.SendAsync(new SetEntryCustomsOfficeSelectionForNotificationById(id, model.CustomsOfficeRequired.GetValueOrDefault()));
 
+            if (backToOverview.GetValueOrDefault())
+            {
+                return RedirectToAction("Index", "Home", new { id });
+            }
             return RedirectToAction("Index", "Shipment", new { id });
         }
     }

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ExitCustomsOfficeController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Controllers/ExitCustomsOfficeController.cs
@@ -25,7 +25,7 @@
         }
 
         [HttpGet]
-        public async Task<ActionResult> Index(Guid id)
+        public async Task<ActionResult> Index(Guid id, bool? backToOverview = null)
         {
             var data = await mediator.SendAsync(new GetExitCustomsOfficeAddDataByNotificationId(id));
 
@@ -72,7 +72,7 @@
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Index(Guid id, CustomsOfficeViewModel model)
+        public async Task<ActionResult> Index(Guid id, CustomsOfficeViewModel model, bool? backToOverview = null)
         {
             var countries = await mediator.SendAsync(new GetEuropeanUnionCountries());
 
@@ -112,7 +112,7 @@
 
             var addSelection = await mediator.SendAsync(new SetExitCustomsOfficeSelectionForNotificationById(id, model.CustomsOfficeRequired.GetValueOrDefault()));
 
-            return RedirectToAction("Index", "EntryCustomsOffice", new { id });
+            return RedirectToAction("Index", "EntryCustomsOffice", new { id, backToOverview = backToOverview });
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/NotificationApplication/Views/Home/_Journey.cshtml
+++ b/src/EA.Iws.Web/Areas/NotificationApplication/Views/Home/_Journey.cshtml
@@ -70,7 +70,7 @@
             </td>
             @if (ViewBag.CanEditNotification)
             {
-                <td class="change">@Html.ActionLink("Change", "Index", "CustomsOffice", new { id }, null)</td>
+                <td class="change">@Html.ActionLink("Change", "Index", "CustomsOffice", new { id, backToOverview = true }, null)</td>
             }
         </tr>
     </tbody>


### PR DESCRIPTION
PBI 67920

backToOverview functionality added to the customs office controllers.

New screen redirection routes are as follows:

1) accessing the customs office screens by clicking change on the notificationOverview:
notificationOverview -> exit customs office -> entry customs office -> notificationOverview
2) accessing the customs office screens via any other route (e.g. notification creation):
origin screen -> exit customs office -> entry customs office -> intended shipments