### PR TITLE
Carrier prenote validations and saving

### DIFF
--- a/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/CreateController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/CreateController.cs
@@ -238,6 +238,8 @@
         [HttpGet]
         public ActionResult WhoAreYourCarriers(Guid notificationId, Guid[] newMovementIds)
         {
+            TempData.Remove("SelectedCarriers");
+
             var model = new WhoAreYourCarrierViewModel();
             model.MovementIds = newMovementIds;
             return View(model);

--- a/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/Create/CarrierViewModel.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/ViewModels/Create/CarrierViewModel.cs
@@ -5,7 +5,6 @@
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.Web.Mvc;
-    using Core.AddressBook;
     using Core.Carriers;
 
     public class CarrierViewModel
@@ -15,6 +14,7 @@
             SelectedCarriers = new List<CarrierList>();
             SelectedCarriersId = new List<Guid>();
         }
+
         public void SetCarriers(IEnumerable<CarrierData> carriers)
         {
             CarriersList = new SelectList(carriers.Select(c => new SelectListItem()
@@ -25,13 +25,14 @@
         }
 
         [Required(ErrorMessage = "Select a carrier from the list")]
-        public Guid SelectedCarrier { get; set; }
+        public Guid? SelectedCarrier { get; set; }
 
         public SelectList CarriersList { get; set; }
 
         public List<CarrierList> SelectedCarriers { get; set; }
 
         public List<Guid> SelectedCarriersId { get; set; }
+
         public IEnumerable<Guid> MovementIds { get; set; }
     }
 }


### PR DESCRIPTION
BUG 67941.

Fix for the main bug is by adding a model error if there aren't any selected carriers. Upon testing the fix, I found that the incorrect (old version) of the ordering for the selected carriers are being saved in to database. Fix for this is to take advantage data being stored in `TempData`. It is being cleared out on the `GET` for "who are your carriers" screen as well as when the user hits save and continue after selecting their carriers ensuring that this data is not being re-used when they re-start the same journey.