### PR TITLE
Changed the ordering of the comments

### DIFF
--- a/src/EA.Iws.Database/scripts/Everytime/02-Views/0017-Reports-Payments.sql
+++ b/src/EA.Iws.Database/scripts/Everytime/02-Views/0017-Reports-Payments.sql
@@ -14,7 +14,7 @@ AS
         (SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
           FROM [Notification].[Transaction] T2
           WHERE T2.NotificationId = N.Id
-		  ORDER BY [Date] ASC
+		  ORDER BY [Date] DESC
           FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)') AS Comments
     FROM [Notification].[Transaction] T
     INNER JOIN [Notification].[Notification] N ON N.Id = T.NotificationId
@@ -32,7 +32,7 @@ AS
         (SELECT CASE WHEN RIGHT(LTRIM(RTRIM(T2.Comments)),1) = '.' THEN LTRIM(RTRIM(T2.Comments)) + ' ' ELSE LTRIM(RTRIM(T2.Comments)) + '. ' END AS Comments
           FROM [ImportNotification].[Transaction] T2
           WHERE T2.NotificationId = N.Id
-		  ORDER BY [Date] ASC
+		  ORDER BY [Date] DESC
           FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)') AS Comments
     FROM [ImportNotification].[Transaction] T
     INNER JOIN [ImportNotification].[Notification] N ON N.Id = T.NotificationId


### PR DESCRIPTION
Final discussions with Mike and Gill have determined that they do want the comments ordered by the transaction date entered by the user, rather than the order the transactions are created. However they would like the order to be by date desc rather than date asc.