### PR TITLE
Bulk receipt recovery notification type header

### DIFF
--- a/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
+++ b/src/EA.Iws.Web/Areas/NotificationMovements/Controllers/ReceiptRecoveryBulkUploadController.cs
@@ -61,6 +61,10 @@
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Upload(Guid notificationId, ReceiptRecoveryBulkUploadViewModel model)
         {
+            var notificationType =
+                (await mediator.SendAsync(new GetNotificationBasicInfo(notificationId))).NotificationType;
+            model.NotificationType = notificationType;
+
             if (!ModelState.IsValid)
             {
                 ViewBag.NotificationId = notificationId;


### PR DESCRIPTION
BUG 67949 - on the error screen for r/r, the notification type is not displaying correctly on the header text.