### PR TITLE
Delete movement carriers correctly.

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/NotificationApplicationRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/NotificationApplicationRepository.cs
@@ -77,7 +77,7 @@
         {
             var rowsAffected = await context.Database.ExecuteSqlCommandAsync(@"
                 DELETE FROM [Notification].[MovementDateHistory] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id)
-                DELETE FROM [Notification].[MovementCarrier] WHERE MovementDetailsId IN (SELECT [Id] FROM [Notification].[MovementDetails] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id))
+                DELETE FROM [Notification].[MovementCarrier] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id)
                 DELETE FROM [Notification].[MovementPackagingInfo] WHERE MovementDetailsId IN (SELECT [Id] FROM [Notification].[MovementDetails] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id))
                 DELETE FROM [Notification].[MovementDetails] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id)
                 DELETE FROM [Notification].[MovementOperationReceipt] WHERE MovementId IN (SELECT [Id] FROM [Notification].[Movement] WHERE NotificationId = @Id)


### PR DESCRIPTION
Follow up to PR #864.

BUG 68095 and 68164

Due to the change for carriers prenotifications, needed to update the delete statement for deleting Notifications.