### PR TITLE
Update deletion of movement carrier when deleting shipments

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
@@ -152,7 +152,7 @@
         public async Task<bool> DeleteById(Guid movementId)
         {
             var rowsAffected = await context.Database.ExecuteSqlCommandAsync(
-                @"DELETE from [Notification].[MovementCarrier] WHERE MovementDetailsId in (SELECT Id FROM [Notification].[MovementDetails] WHERE MovementId = @movementId)
+                @"DELETE from [Notification].[MovementCarrier] WHERE MovementId = @movementId
                   DELETE from [Notification].[MovementPackagingInfo] WHERE MovementDetailsId in (SELECT Id FROM [Notification].[MovementDetails] WHERE MovementId = @movementId)
                   DELETE from [Notification].[MovementDetails] WHERE MovementId = @movementId
                   DELETE from [Notification].[MovementDateHistory] WHERE MovementId = @movementId


### PR DESCRIPTION
BUG 68164

Due to the change for carriers prenotifications, needed to update the delete statement for deleting Notifications.