### PR TITLE
Added the 'go to summary' links to search results

### DIFF
--- a/src/EA.Iws.Core/Admin/Search/BasicSearchResults.cs
+++ b/src/EA.Iws.Core/Admin/Search/BasicSearchResults.cs
@@ -13,5 +13,7 @@
         public string ExporterName { get; set; }
 
         public string WasteType { get; set; }
+
+        public bool ShowShipmentSummaryLink { get; set; }
     }
 }

--- a/src/EA.Iws.Core/Admin/Search/ExportAdvancedSearchResult.cs
+++ b/src/EA.Iws.Core/Admin/Search/ExportAdvancedSearchResult.cs
@@ -13,5 +13,7 @@
         public string ExporterName { get; set; }
 
         public string WasteType { get; set; }
+
+        public bool ShowShipmentSummaryLink { get; set; }
     }
 }

--- a/src/EA.Iws.Core/Admin/Search/ImportAdvancedSearchResult.cs
+++ b/src/EA.Iws.Core/Admin/Search/ImportAdvancedSearchResult.cs
@@ -1,7 +1,6 @@
 ﻿namespace EA.Iws.Core.Admin.Search
 {
     using System;
-    using ImportNotificationAssessment;
 
     public class ImportAdvancedSearchResult
     {
@@ -14,5 +13,7 @@
         public string Exporter { get; set; }
 
         public string BaselOecdCode { get; set; }
+
+        public bool ShowShipmentSummaryLink { get; set; }
     }
 }

--- a/src/EA.Iws.Core/Admin/Search/ImportSearchResult.cs
+++ b/src/EA.Iws.Core/Admin/Search/ImportSearchResult.cs
@@ -13,5 +13,7 @@
         public NotificationType NotificationType { get; set; }
 
         public ImportNotificationStatus Status { get; set; }
+
+        public bool ShowShipmentSummaryLink { get; set; }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationSearchRepository.cs
@@ -4,6 +4,7 @@
     using System.Data.Entity;
     using System.Linq;
     using System.Threading.Tasks;
+    using Core.ImportNotificationAssessment;
     using Domain.ImportNotification;
     using Prsd.Core.Domain;
 
@@ -59,7 +60,8 @@
                 x.Assessment.Status,
                 x.Exporter == null ? string.Empty : x.Exporter.Name,
                 x.Importer == null ? string.Empty : x.Importer.Name,
-                x.Notification.NotificationType));
+                x.Notification.NotificationType,
+                x.Assessment.Status.Equals(ImportNotificationStatus.Consented) || x.Assessment.Status.Equals(ImportNotificationStatus.ConsentWithdrawn)));
         }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
@@ -134,7 +134,7 @@
                     S.[Description] AS [Status],
                     E.Name AS [Exporter],
                     CASE WHEN WT.BaselOecdCodeNotListed = 1 THEN 'Not listed' ELSE WC.Code END AS [BaselOecdCode],
-					CASE WHEN S.[Description] IN ('{1}', '{2}') THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS [ShowShipmentSummaryLink]
+                    CASE WHEN S.[Description] IN ('{1}', '{2}') THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS [ShowShipmentSummaryLink]
                 FROM
                     [ImportNotification].[Notification] N
                     INNER JOIN [ImportNotification].[NotificationAssessment] NA ON N.Id = NA.NotificationApplicationId

--- a/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
@@ -73,7 +73,7 @@
                     NS.[Description] AS [NotificationStatus],
                     E.[Name] AS [ExporterName],
                     CCT.[Description] AS [WasteType],
-					CASE WHEN NS.[Description] IN ('{1}', '{2}') AND FG.Id IS NOT NULL THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) 
+                    CASE WHEN NS.[Description] IN ('{1}', '{2}') AND FG.Id IS NOT NULL THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) 
                         END AS [ShowShipmentSummaryLink]
                 FROM
                     [Notification].[Notification] N
@@ -85,10 +85,10 @@
                         INNER JOIN [Lookup].[ChemicalCompositionType] CCT ON WT.ChemicalCompositionType = CCT.Id
                     ON N.Id = WT.NotificationId
                     LEFT JOIN  [Notification].[FinancialGuaranteeCollection] FGC ON FGC.[NotificationId] = N.Id
-						LEFT JOIN [Notification].[FinancialGuarantee] FG ON FG.Id = 
-							(SELECT TOP 1 FG1.Id from [Notification].[FinancialGuarantee] FG1 
-							WHERE FG1.FinancialGuaranteeCollectionId = FGC.Id
-							AND FG1.Status = {3})
+                        LEFT JOIN [Notification].[FinancialGuarantee] FG ON FG.Id = 
+                            (SELECT TOP 1 FG1.Id from [Notification].[FinancialGuarantee] FG1 
+                            WHERE FG1.FinancialGuaranteeCollectionId = FGC.Id
+                            AND FG1.Status = {3})
                 WHERE
                     N.[Id] IN ({0})";
 

--- a/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
@@ -67,7 +67,8 @@
                     N.[NotificationNumber],
                     NS.[Description] AS [NotificationStatus],
                     E.[Name] AS [ExporterName],
-                    CCT.[Description] AS [WasteType]
+                    CCT.[Description] AS [WasteType],
+					CASE WHEN NS.[Description] IN ('Consented', 'Consent withdrawn') THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS [ShowShipmentSummaryLink]
                 FROM
                     [Notification].[Notification] N
                     INNER JOIN [Notification].[NotificationAssessment] NA 

--- a/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Search/AdvancedSearchRepository.cs
@@ -107,7 +107,8 @@
                     N.[NotificationNumber],
                     S.[Description] AS [Status],
                     E.Name AS [Exporter],
-                    CASE WHEN WT.BaselOecdCodeNotListed = 1 THEN 'Not listed' ELSE WC.Code END AS [BaselOecdCode]
+                    CASE WHEN WT.BaselOecdCodeNotListed = 1 THEN 'Not listed' ELSE WC.Code END AS [BaselOecdCode],
+					CASE WHEN S.[Description] IN ('Consented', 'Consent withdrawn') THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS [ShowShipmentSummaryLink]
                 FROM
                     [ImportNotification].[Notification] N
                     INNER JOIN [ImportNotification].[NotificationAssessment] NA ON N.Id = NA.NotificationApplicationId

--- a/src/EA.Iws.Domain/ImportNotification/ImportNotificationSearchResult.cs
+++ b/src/EA.Iws.Domain/ImportNotification/ImportNotificationSearchResult.cs
@@ -18,12 +18,15 @@
 
         public NotificationType NotificationType { get; private set; }
 
+        public bool ShowShipmentSummaryLink { get; private set; }
+
         public ImportNotificationSearchResult(Guid notificationId,
             string number, 
             ImportNotificationStatus status, 
             string exporter, 
             string importer,
-            NotificationType notificationType)
+            NotificationType notificationType,
+            bool showSummaryLink)
         {
             NotificationId = notificationId;
             NotificationType = notificationType;
@@ -31,6 +34,7 @@
             Status = status;
             Exporter = exporter;
             Importer = importer;
+            ShowShipmentSummaryLink = showSummaryLink;
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers/Admin/Search/SearchExportNotificationsHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Admin/Search/SearchExportNotificationsHandler.cs
@@ -62,11 +62,12 @@
                 s.NotificationNumber,
                 s.ExporterName,
                 s.WasteType,
-                s.Status)).ToList();
+                s.Status,
+                s.Status.Equals(NotificationStatus.Consented) || s.Status.Equals(NotificationStatus.ConsentWithdrawn))).ToList();
         }
 
         private static BasicSearchResult ConvertToSearchResults(Guid notificationId, string notificationNumber,
-            string exporterName, ChemicalComposition wasteTypeValue, NotificationStatus status)
+            string exporterName, ChemicalComposition wasteTypeValue, NotificationStatus status, bool showSummaryLink)
         {
             var searchResult = new BasicSearchResult
             {
@@ -75,7 +76,8 @@
                 ExporterName = exporterName,
                 WasteType = wasteTypeValue != default(ChemicalComposition)
                     ? EnumHelper.GetShortName(wasteTypeValue) : string.Empty,
-                NotificationStatus = EnumHelper.GetDisplayName(status)
+                NotificationStatus = EnumHelper.GetDisplayName(status),
+                ShowShipmentSummaryLink = showSummaryLink
             };
 
             return searchResult;

--- a/src/EA.Iws.RequestHandlers/Mappings/ImportNotification/SearchResultMap.cs
+++ b/src/EA.Iws.RequestHandlers/Mappings/ImportNotification/SearchResultMap.cs
@@ -13,7 +13,8 @@
                 Id = source.NotificationId,
                 NotificationType = source.NotificationType,
                 NotificationNumber = source.Number,
-                Status = source.Status
+                Status = source.Status,
+                ShowShipmentSummaryLink = source.ShowShipmentSummaryLink
             };
         }
     }

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
@@ -45,6 +45,10 @@
                         @Html.DisplayFor(m => m.ExportResults[i].WasteType)
                     </td>
                     <td>
+                        @if (Model.ExportResults[i].ShowShipmentSummaryLink)
+                        {
+                            @Html.ActionLink(@Resources.ShipmentSummaryLinkText, "Index", "Home", new { area = "AdminExportNotificationMovements", id = Model.ExportResults[i].Id }, null)
+                        }
                     </td>
                 </tr>
             }
@@ -93,7 +97,7 @@ else
                     <td>
                         @if (Model.ImportResults[i].ShowShipmentSummaryLink)
                         {
-                            @Resources.ShipmentSummaryLinkText
+                            @Html.ActionLink(@Resources.ShipmentSummaryLinkText, "Index", "Home", new { area = "AdminImportNotificationMovements", id = Model.ImportResults[i].Id }, null)
                         }
                     </td>
                 </tr>

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
@@ -21,6 +21,7 @@
                 <th>@Resources.StatusTableHeading</th>
                 <th>@Resources.CompanyNameTableHeading</th>
                 <th>@Resources.WasteTypeTableHeading</th>
+                <th>@Resources.ShipmentSummaryTableHeading</th>
             </tr>
         </thead>
         <tbody>
@@ -43,6 +44,8 @@
                     <td>
                         @Html.DisplayFor(m => m.ExportResults[i].WasteType)
                     </td>
+                    <td>
+                    </td>
                 </tr>
             }
         </tbody>
@@ -64,6 +67,7 @@ else
                 <th>@Resources.StatusTableHeading</th>
                 <th>@Resources.CompanyNameTableHeading</th>
                 <th>@Resources.BaselCodeTableHeading</th>
+                <th>@Resources.ShipmentSummaryTableHeading</th>
             </tr>
         </thead>
         <tbody>
@@ -85,6 +89,8 @@ else
                     </td>
                     <td>
                         @Html.DisplayFor(m => m.ImportResults[i].BaselOecdCode)
+                    </td>
+                    <td>
                     </td>
                 </tr>
             }

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/Results.cshtml
@@ -91,6 +91,10 @@ else
                         @Html.DisplayFor(m => m.ImportResults[i].BaselOecdCode)
                     </td>
                     <td>
+                        @if (Model.ImportResults[i].ShowShipmentSummaryLink)
+                        {
+                            @Resources.ShipmentSummaryLinkText
+                        }
                     </td>
                 </tr>
             }

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.Designer.cs
@@ -151,6 +151,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.AdvancedSearch {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shipment summary.
+        /// </summary>
+        public static string ShipmentSummaryTableHeading {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryTableHeading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Status.
         /// </summary>
         public static string StatusTableHeading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.Designer.cs
@@ -151,6 +151,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.AdvancedSearch {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go to summary.
+        /// </summary>
+        public static string ShipmentSummaryLinkText {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryLinkText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shipment summary.
         /// </summary>
         public static string ShipmentSummaryTableHeading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.resx
@@ -147,6 +147,9 @@
   <data name="NotificationNumberTableHeading" xml:space="preserve">
     <value>Notification number</value>
   </data>
+  <data name="ShipmentSummaryLinkText" xml:space="preserve">
+    <value>Go to summary</value>
+  </data>
   <data name="ShipmentSummaryTableHeading" xml:space="preserve">
     <value>Shipment summary</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/AdvancedSearch/ResultsResources.resx
@@ -147,6 +147,9 @@
   <data name="NotificationNumberTableHeading" xml:space="preserve">
     <value>Notification number</value>
   </data>
+  <data name="ShipmentSummaryTableHeading" xml:space="preserve">
+    <value>Shipment summary</value>
+  </data>
   <data name="StatusTableHeading" xml:space="preserve">
     <value>Status</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.Designer.cs
@@ -97,6 +97,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.Home {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go to summary.
+        /// </summary>
+        public static string ShipmentSummaryLinkText {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryLinkText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shipment summary.
         /// </summary>
         public static string ShipmentSummaryTableHeading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.Designer.cs
@@ -97,6 +97,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.Home {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shipment summary.
+        /// </summary>
+        public static string ShipmentSummaryTableHeading {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryTableHeading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import notifications.
         /// </summary>
         public static string Subheading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.resx
@@ -129,6 +129,9 @@
   <data name="ResultsCount" xml:space="preserve">
     <value>Your search returned {0} import notification(s)</value>
   </data>
+  <data name="ShipmentSummaryLinkText" xml:space="preserve">
+    <value>Go to summary</value>
+  </data>
   <data name="ShipmentSummaryTableHeading" xml:space="preserve">
     <value>Shipment summary</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/ImportResultsResources.resx
@@ -129,6 +129,9 @@
   <data name="ResultsCount" xml:space="preserve">
     <value>Your search returned {0} import notification(s)</value>
   </data>
+  <data name="ShipmentSummaryTableHeading" xml:space="preserve">
+    <value>Shipment summary</value>
+  </data>
   <data name="Subheading" xml:space="preserve">
     <value>Import notifications</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/Index.cshtml
@@ -65,6 +65,10 @@
                         @Html.DisplayFor(m => m.ExportSearchResults[i].WasteType)
                     </td>
                     <td>
+                        @if (Model.ExportSearchResults[i].ShowShipmentSummaryLink)
+                        {
+                            @Html.ActionLink(@Resource.ShipmentSummaryLinkText, "Index", "Home", new { area = "AdminExportNotificationMovements", id = Model.ExportSearchResults[i].Id }, null)
+                        }
                     </td>
                 </tr>
             }

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/Index.cshtml
@@ -41,6 +41,7 @@
                 <th>@Resource.StatusTableHeading</th>
                 <th>@Resource.CompanyNameTableHeading</th>
                 <th>@Resource.WasteTypeTableHeading</th>
+                <th>@Resource.ShipmentSummaryTableHeading</th>
             </tr>
         </thead>
         <tbody>
@@ -62,6 +63,8 @@
                     </td>
                     <td>
                         @Html.DisplayFor(m => m.ExportSearchResults[i].WasteType)
+                    </td>
+                    <td>
                     </td>
                 </tr>
             }

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.Designer.cs
@@ -250,6 +250,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.Home {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shipment summary.
+        /// </summary>
+        public static string ShipmentSummaryTableHeading {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryTableHeading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Status.
         /// </summary>
         public static string StatusTableHeading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.Designer.cs
@@ -250,6 +250,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.Home {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go to summary.
+        /// </summary>
+        public static string ShipmentSummaryLinkText {
+            get {
+                return ResourceManager.GetString("ShipmentSummaryLinkText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shipment summary.
         /// </summary>
         public static string ShipmentSummaryTableHeading {

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.resx
@@ -180,6 +180,9 @@
   <data name="SearchPlaceholder" xml:space="preserve">
     <value>Enter notification number or organisation name</value>
   </data>
+  <data name="ShipmentSummaryTableHeading" xml:space="preserve">
+    <value>Shipment summary</value>
+  </data>
   <data name="StatusTableHeading" xml:space="preserve">
     <value>Status</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/IndexResources.resx
@@ -180,6 +180,9 @@
   <data name="SearchPlaceholder" xml:space="preserve">
     <value>Enter notification number or organisation name</value>
   </data>
+  <data name="ShipmentSummaryLinkText" xml:space="preserve">
+    <value>Go to summary</value>
+  </data>
   <data name="ShipmentSummaryTableHeading" xml:space="preserve">
     <value>Shipment summary</value>
   </data>

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/_ImportResults.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/_ImportResults.cshtml
@@ -16,7 +16,7 @@
             <th>@Resource.NotificationNumberTableHeading</th>
             <th>Status</th>
             <th>@Resource.NotificationTypeTableHeading</th>
-            <th>Shipment summary</th>
+            <th>@Resource.ShipmentSummaryTableHeading</th>
         </tr>
     </thead>
     <tbody>
@@ -37,6 +37,10 @@
                 @Html.DisplayFor(m => m.ImportSearchResults[i].NotificationType)
             </td>
             <td>
+                @if (Model.ImportSearchResults[i].ShowShipmentSummaryLink)
+                {
+                    @Html.ActionLink(@Resource.ShipmentSummaryLinkText, "Index", "Home", new { area = "AdminImportNotificationMovements", id = Model.ImportSearchResults[i].Id }, null)
+                }
             </td>
         </tr>
         }

--- a/src/EA.Iws.Web/Areas/Admin/Views/Home/_ImportResults.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/Home/_ImportResults.cshtml
@@ -16,6 +16,7 @@
             <th>@Resource.NotificationNumberTableHeading</th>
             <th>Status</th>
             <th>@Resource.NotificationTypeTableHeading</th>
+            <th>Shipment summary</th>
         </tr>
     </thead>
     <tbody>
@@ -34,6 +35,8 @@
             </td>
             <td>
                 @Html.DisplayFor(m => m.ImportSearchResults[i].NotificationType)
+            </td>
+            <td>
             </td>
         </tr>
         }


### PR DESCRIPTION
PBIs: 67662, 67670 and 67672

New column added to each of the search result tables:
- Basic import notification search
- Basic export notification search
- Advanced import notification search
- Advanced export notification search

Column contains a link to the relevant summary page for the notification, if the notification meets certain criteria (the correct notification status and, for export notifications, the correct financial guarantee status).