### PR TITLE
Fix search for import notification to remove spaces.

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationSearchRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationSearchRepository.cs
@@ -29,7 +29,7 @@
 
             var query = from notification
                 in importNotificationContext.ImportNotifications
-                where notification.NotificationNumber.Contains(number)
+                where notification.NotificationNumber.Replace(" ", string.Empty).Contains(number.Replace(" ", string.Empty))
                     && notification.CompetentAuthority == userCompetentAuthority
                 from assessment 
                     in importNotificationContext.ImportNotificationAssessments


### PR DESCRIPTION
BUG 68637

Remove white spaces when comparing notification numbers for import notifications.

Existing bug.