### PR TITLE
Active load rule - additional work

### DIFF
--- a/src/EA.Iws.Core/Movement/RemainingShipmentsData.cs
+++ b/src/EA.Iws.Core/Movement/RemainingShipmentsData.cs
@@ -4,8 +4,6 @@
     {
         public int ActiveLoadsPermitted { get; set; }
 
-        public int ActiveLoadsRemaining { get; set; }
-
         public int ActiveLoadsRemainingByDate { get; set; }
 
         public int ShipmentsRemaining { get; set; }      

--- a/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
@@ -120,7 +120,9 @@
                 .Where(m =>
                     m.NotificationId == notificationId
                     && (m.Status == MovementStatus.Submitted
-                        || m.Status == MovementStatus.Received)
+                        || m.Status == MovementStatus.Received
+                        || m.Status == MovementStatus.New
+                        || m.Status == MovementStatus.Captured)
                     && m.Date < SystemTime.UtcNow).ToArrayAsync();
 
             return currentActiveLoads;
@@ -134,7 +136,9 @@
                 .Where(m =>
                     m.NotificationId == notificationId
                     && (m.Status == MovementStatus.Submitted
-                        || m.Status == MovementStatus.Received)
+                        || m.Status == MovementStatus.Received
+                        || m.Status == MovementStatus.New
+                        || m.Status == MovementStatus.Captured)
                     && m.Date >= SystemTime.UtcNow).ToArrayAsync();
 
             return currentActiveLoads;

--- a/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
@@ -139,7 +139,7 @@
                         || m.Status == MovementStatus.Received
                         || m.Status == MovementStatus.New
                         || m.Status == MovementStatus.Captured)
-                    && m.Date >= SystemTime.UtcNow).ToArrayAsync();
+                    && DbFunctions.TruncateTime(m.Date) >= SystemTime.UtcNow.Date).ToArrayAsync();
 
             return currentActiveLoads;
         }

--- a/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementRepository.cs
@@ -112,7 +112,7 @@
             return movements;
         }
 
-        public async Task<IEnumerable<Movement>> GetActiveMovements(Guid notificationId)
+        public async Task<IEnumerable<Movement>> GetAllActiveMovements(Guid notificationId)
         {
             await notificationAuthorization.EnsureAccessAsync(notificationId);
 
@@ -122,24 +122,7 @@
                     && (m.Status == MovementStatus.Submitted
                         || m.Status == MovementStatus.Received
                         || m.Status == MovementStatus.New
-                        || m.Status == MovementStatus.Captured)
-                    && m.Date < SystemTime.UtcNow).ToArrayAsync();
-
-            return currentActiveLoads;
-        }
-
-        public async Task<IEnumerable<Movement>> GetFutureActiveMovements(Guid notificationId)
-        {
-            await notificationAuthorization.EnsureAccessAsync(notificationId);
-
-            var currentActiveLoads = await context.Movements
-                .Where(m =>
-                    m.NotificationId == notificationId
-                    && (m.Status == MovementStatus.Submitted
-                        || m.Status == MovementStatus.Received
-                        || m.Status == MovementStatus.New
-                        || m.Status == MovementStatus.Captured)
-                    && DbFunctions.TruncateTime(m.Date) >= SystemTime.UtcNow.Date).ToArrayAsync();
+                        || m.Status == MovementStatus.Captured)).ToArrayAsync();
 
             return currentActiveLoads;
         }

--- a/src/EA.Iws.DataAccess/Repositories/NotificationMovementsSummaryRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/NotificationMovementsSummaryRepository.cs
@@ -62,7 +62,9 @@
                 .Where(m => 
                     m.NotificationId == notificationId
                     && (m.Status == MovementStatus.Submitted 
-                        || m.Status == MovementStatus.Received) 
+                        || m.Status == MovementStatus.Received
+                        || m.Status == MovementStatus.New
+                        || m.Status == MovementStatus.Captured) 
                     && m.Date < SystemTime.UtcNow)
                 .CountAsync();
 

--- a/src/EA.Iws.Domain.Tests.Unit/Movement/MovementFactoryTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/Movement/MovementFactoryTests.cs
@@ -112,7 +112,7 @@
         {
             SetupMovements(500, 100);
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
             var date = Today.AddDays(5);
 
@@ -133,7 +133,7 @@
                 .Returns(new TestableNotificationAssessment { Status = NotificationStatus.Consented });
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(1));
             A.CallTo(() => consentRepository.GetByNotificationId(NotificationId)).Returns(ValidConsent());
 
             var movement = await factory.Create(NotificationId, Today);
@@ -153,7 +153,7 @@
                 .Returns(new TestableNotificationAssessment { Status = NotificationStatus.Consented });
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(2));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => factory.Create(NotificationId, Today));
         }
@@ -180,7 +180,7 @@
             SetupMovements(1000, 900);
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
             await factory.Create(NotificationId, Today);
         }

--- a/src/EA.Iws.Domain.Tests.Unit/Movement/MovementFactoryTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/Movement/MovementFactoryTests.cs
@@ -72,7 +72,7 @@
         [Fact]
         public async Task NewMovementExceedsShipmentLimit_Throws()
         {
-            CreateShipmentInfo(maxNumberOfShipments: 1);
+            CreateShipmentInfo(1);
 
             var existingMovement = new TestableMovement
             {
@@ -88,7 +88,7 @@
         [Fact]
         public async Task NotificationNotConsented_Throws()
         {
-            CreateShipmentInfo(maxNumberOfShipments: 1);
+            CreateShipmentInfo(1);
 
             A.CallTo(() => movementRepository.GetAllMovements(NotificationId)).Returns(new Movement[0]);
 
@@ -112,7 +112,7 @@
         {
             SetupMovements(500, 100);
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
             var date = Today.AddDays(5);
 
@@ -124,7 +124,7 @@
         [Fact]
         public async Task ReturnsMovement()
         {
-            CreateShipmentInfo(maxNumberOfShipments: 1);
+            CreateShipmentInfo(1);
 
             A.CallTo(() => movementRepository.GetAllMovements(NotificationId))
                 .Returns(new Movement[0]);
@@ -133,7 +133,7 @@
                 .Returns(new TestableNotificationAssessment { Status = NotificationStatus.Consented });
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
             A.CallTo(() => consentRepository.GetByNotificationId(NotificationId)).Returns(ValidConsent());
 
             var movement = await factory.Create(NotificationId, Today);
@@ -142,9 +142,9 @@
         }
 
         [Fact]
-        public async Task CurrentActiveLoadsEqualsPermitted_Throws()
+        public async Task CurrentActiveLoadByDateEqualsPermitted_Throws()
         {
-            CreateShipmentInfo(maxNumberOfShipments: 1);
+            CreateShipmentInfo(1);
 
             A.CallTo(() => movementRepository.GetAllMovements(NotificationId))
                 .Returns(new Movement[0]);
@@ -153,7 +153,7 @@
                 .Returns(new TestableNotificationAssessment { Status = NotificationStatus.Consented });
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => factory.Create(NotificationId, Today));
         }
@@ -180,7 +180,7 @@
             SetupMovements(1000, 900);
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
             await factory.Create(NotificationId, Today);
         }

--- a/src/EA.Iws.Domain.Tests.Unit/Movement/NumberOfActiveLoadsTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/Movement/NumberOfActiveLoadsTests.cs
@@ -34,7 +34,7 @@
         public async Task ActiveLoadsPermittedReached_ReturnsTrue()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(2));
 
             var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
 
@@ -45,7 +45,7 @@
         public async Task ActiveLoadsPermittedExceeded_ReturnsTrue()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(3));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(3));
 
             var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
 
@@ -56,7 +56,7 @@
         public async Task ActiveLoadsPermittedNotReached_ReturnsFalse()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
             var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
 
@@ -67,7 +67,7 @@
         public async Task ActiveLoadsPermittedReached_NewMovementForDifferentDate_ReturnsFalse()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetMovementArray(2));
 
             var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow.AddDays(5));
 

--- a/src/EA.Iws.Domain.Tests.Unit/Movement/NumberOfActiveLoadsTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/Movement/NumberOfActiveLoadsTests.cs
@@ -34,9 +34,9 @@
         public async Task ActiveLoadsPermittedReached_ReturnsTrue()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
 
-            var result = await numberOfActiveLoads.HasMaximum(NotificationId);
+            var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
 
             Assert.True(result);
         }
@@ -45,9 +45,9 @@
         public async Task ActiveLoadsPermittedExceeded_ReturnsTrue()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(3));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(3));
 
-            var result = await numberOfActiveLoads.HasMaximum(NotificationId);
+            var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
 
             Assert.True(result);
         }
@@ -56,9 +56,20 @@
         public async Task ActiveLoadsPermittedNotReached_ReturnsFalse()
         {
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetMovementArray(1));
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(1));
 
-            var result = await numberOfActiveLoads.HasMaximum(NotificationId);
+            var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ActiveLoadsPermittedReached_NewMovementForDifferentDate_ReturnsFalse()
+        {
+            A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId)).Returns(GetFinancialGuarantee());
+            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId)).Returns(GetMovementArray(2));
+
+            var result = await numberOfActiveLoads.HasMaximum(NotificationId, SystemTime.UtcNow.AddDays(5));
 
             Assert.False(result);
         }

--- a/src/EA.Iws.Domain/Movement/IMovementRepository.cs
+++ b/src/EA.Iws.Domain/Movement/IMovementRepository.cs
@@ -23,9 +23,7 @@
 
         Task<Movement> GetByNumberOrDefault(int movementNumber, Guid notificationId);
 
-        Task<IEnumerable<Movement>> GetActiveMovements(Guid notificationId);
-
-        Task<IEnumerable<Movement>> GetFutureActiveMovements(Guid notificationId);
+        Task<IEnumerable<Movement>> GetAllActiveMovements(Guid notificationId);
 
         void Add(Movement movement);
 

--- a/src/EA.Iws.Domain/Movement/MovementFactory.cs
+++ b/src/EA.Iws.Domain/Movement/MovementFactory.cs
@@ -57,7 +57,7 @@
                         notificationId));
             }
             
-            var hasMaximumActiveLoads = await numberOfActiveLoads.HasMaximum(notificationId);
+            var hasMaximumActiveLoads = await numberOfActiveLoads.HasMaximum(notificationId, actualMovementDate);
 
             if (hasMaximumActiveLoads)
             {

--- a/src/EA.Iws.Domain/Movement/NumberOfActiveLoads.cs
+++ b/src/EA.Iws.Domain/Movement/NumberOfActiveLoads.cs
@@ -19,18 +19,21 @@
             this.financialGuaranteeRepository = financialGuaranteeRepository;
         }
 
-        public async Task<bool> HasMaximum(Guid notificationId)
+        public async Task<bool> HasMaximum(Guid notificationId, DateTime actualMovementDate)
         {
-            var currentActiveLoads = (await movementRepository.GetActiveMovements(notificationId)).Count();
             var financialGuaranteeCollection = await financialGuaranteeRepository.GetByNotificationId(notificationId);
 
             var currentFinancialGuarantee =
                 financialGuaranteeCollection.FinancialGuarantees.SingleOrDefault(
                     fg => fg.Status == FinancialGuaranteeStatus.Approved);
 
+            var futureActiveShipmentsByDate =
+                (await movementRepository.GetFutureActiveMovements(notificationId)).Count(
+                    m => m.Date.Date == actualMovementDate.Date);
+
             var activeLoadsPermitted = currentFinancialGuarantee == null ? 0 : currentFinancialGuarantee.ActiveLoadsPermitted.GetValueOrDefault();
 
-            return currentActiveLoads >= activeLoadsPermitted;
+            return futureActiveShipmentsByDate >= activeLoadsPermitted;
         }
     }
 }

--- a/src/EA.Iws.Domain/Movement/NumberOfActiveLoads.cs
+++ b/src/EA.Iws.Domain/Movement/NumberOfActiveLoads.cs
@@ -27,13 +27,13 @@
                 financialGuaranteeCollection.FinancialGuarantees.SingleOrDefault(
                     fg => fg.Status == FinancialGuaranteeStatus.Approved);
 
-            var futureActiveShipmentsByDate =
-                (await movementRepository.GetFutureActiveMovements(notificationId)).Count(
+            var activeShipmentsByDate =
+                (await movementRepository.GetAllActiveMovements(notificationId)).Count(
                     m => m.Date.Date == actualMovementDate.Date);
 
             var activeLoadsPermitted = currentFinancialGuarantee == null ? 0 : currentFinancialGuarantee.ActiveLoadsPermitted.GetValueOrDefault();
 
-            return futureActiveShipmentsByDate >= activeLoadsPermitted;
+            return activeShipmentsByDate >= activeLoadsPermitted;
         }
     }
 }

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkPrenotification/PerformBulkUploadContentValidationHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkPrenotification/PerformBulkUploadContentValidationHandlerTests.cs
@@ -87,7 +87,7 @@
             };
 
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(notificationId)).Returns(testCollection);
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(notificationId))
+            A.CallTo(() => movementRepository.GetAllActiveMovements(notificationId))
                 .Returns(testFutureActiveMovements);
 
             handler = new PerformPrenotificationContentValidationHandler(contentRules, mapper, repository, movementRepository, financialGuaranteeRepository);

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkPrenotification/PrenotificationQuantityExceededRuleTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/BulkPrenotification/PrenotificationQuantityExceededRuleTests.cs
@@ -25,7 +25,14 @@
             int intendedQuantity = 100;
             int quantityReceived = 80;
 
-            A.CallTo(() => repo.GetById(notificationId)).Returns(NotificationMovementsSummary.Load(notificationId, string.Empty, Core.Shared.NotificationType.Disposal, 10, 5, 10, 5, intendedQuantity, quantityReceived, Core.Shared.ShipmentQuantityUnits.Kilograms, Core.FinancialGuarantee.FinancialGuaranteeStatus.Approved, Core.Notification.UKCompetentAuthority.England, Core.NotificationAssessment.NotificationStatus.Consented, new Domain.ShipmentQuantity(1, Core.Shared.ShipmentQuantityUnits.Kilograms)));
+            A.CallTo(() => repo.GetById(notificationId))
+                .Returns(NotificationMovementsSummary.Load(notificationId, string.Empty,
+                    Core.Shared.NotificationType.Disposal, 10, 5, 10, 5, intendedQuantity, quantityReceived,
+                    Core.Shared.ShipmentQuantityUnits.Kilograms,
+                    Core.FinancialGuarantee.FinancialGuaranteeStatus.Approved,
+                    Core.Notification.UKCompetentAuthority.England,
+                    Core.NotificationAssessment.NotificationStatus.Consented,
+                    new Domain.ShipmentQuantity(1, Core.Shared.ShipmentQuantityUnits.Kilograms)));
         }
 
         [Fact]

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/Create/GetRemainingShipmentsHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/Create/GetRemainingShipmentsHandlerTests.cs
@@ -80,17 +80,6 @@
         }
 
         [Fact]
-        public async Task GetRemainingShipmentsHandler_GetsActiveMovements()
-        {
-            var request = new GetRemainingShipments(NotificationId);
-
-            await handler.HandleAsync(request);
-
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId))
-                .MustHaveHappened(Repeated.Exactly.Once);
-        }
-
-        [Fact]
         public async Task GetRemainingShipmentsHandler_GetsFinancialGuaranteeCollection()
         {
             var request = new GetRemainingShipments(NotificationId);
@@ -108,7 +97,7 @@
 
             await handler.HandleAsync(request);
 
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId))
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId))
                 .MustNotHaveHappened();
         }
 
@@ -119,7 +108,7 @@
 
             await handler.HandleAsync(request);
 
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId))
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -134,7 +123,6 @@
             var response = await handler.HandleAsync(request);
 
             Assert.Equal(ActiveLoadsPermitted, response.ActiveLoadsPermitted);
-            Assert.Equal(ActiveLoadsPermitted - ActiveMovements, response.ActiveLoadsRemaining);
             Assert.Equal(MaxNumberOfShipments - TotalMovements, response.ShipmentsRemaining);
         }
 
@@ -150,7 +138,6 @@
             var response = await handler.HandleAsync(request);
 
             Assert.Equal(noApprovedFGActiveLoads, response.ActiveLoadsPermitted);
-            Assert.Equal(noApprovedFGActiveLoads - ActiveMovements, response.ActiveLoadsRemaining);
         }
 
         [Fact]
@@ -164,7 +151,7 @@
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId))
                 .Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Approved));
 
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId))
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId))
                 .Returns(GetShipments(futureShipmentsTotal, futureShipmentsDate));
 
             var response = await handler.HandleAsync(request);
@@ -184,7 +171,7 @@
             A.CallTo(() => financialGuaranteeRepository.GetByNotificationId(NotificationId))
                 .Returns(GetFinancialGuarantee(FinancialGuaranteeStatus.Refused));
 
-            A.CallTo(() => movementRepository.GetFutureActiveMovements(NotificationId))
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId))
                 .Returns(GetShipments(futureShipmentsTotal, futureShipmentsDate));
 
             var response = await handler.HandleAsync(request);

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/Create/GetRemainingShipmentsHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/NotificationMovements/Create/GetRemainingShipmentsHandlerTests.cs
@@ -52,7 +52,7 @@
 
             A.CallTo(() => shipmentRepository.GetByNotificationId(NotificationId)).Returns(shipment);
             A.CallTo(() => movementRepository.GetAllMovements(NotificationId)).Returns(GetShipments(TotalMovements, Today));
-            A.CallTo(() => movementRepository.GetActiveMovements(NotificationId)).Returns(GetShipments(ActiveMovements, Today));
+            A.CallTo(() => movementRepository.GetAllActiveMovements(NotificationId)).Returns(GetShipments(ActiveMovements, Today));
 
             handler = new GetRemainingShipmentsHandler(movementRepository, shipmentRepository, financialGuaranteeRepository);
         }

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/BulkPrenotification/PerformPrenotificationContentValidationHandler.cs
@@ -155,7 +155,7 @@
                 return rules;
             }
 
-            var existingMovements = await movementRepository.GetFutureActiveMovements(notificationId);
+            var existingMovements = await movementRepository.GetAllActiveMovements(notificationId);
 
             var newAndExistingGroupedByDate =
                 movements.Where(m => m.ActualDateOfShipment.HasValue && m.ShipmentNumber.HasValue)

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Create/GetRemainingShipmentsHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Create/GetRemainingShipmentsHandler.cs
@@ -31,7 +31,6 @@
                 (await shipmentRepository.GetByNotificationId(message.NotificationId)).NumberOfShipments;
             var currentNumberOfShipments = (await movementRepository.GetAllMovements(message.NotificationId)).Count();
 
-            var currentActiveLoads = (await movementRepository.GetActiveMovements(message.NotificationId)).Count();
             var financialGuaranteeCollection = await financialGuaranteeRepository.GetByNotificationId(message.NotificationId);
 
             var currentFinancialGuarantee =
@@ -40,19 +39,17 @@
 
             var activeLoadsPermitted = currentFinancialGuarantee == null ? 0 : currentFinancialGuarantee.ActiveLoadsPermitted.GetValueOrDefault();
 
-            var futureActiveShipmentsByDate = message.ShipmentDate.HasValue
-                ? (await movementRepository.GetFutureActiveMovements(message.NotificationId)).Count(
+            var activeShipmentsByDate = message.ShipmentDate.HasValue
+                ? (await movementRepository.GetAllActiveMovements(message.NotificationId)).Count(
                     m => m.Date.Date == message.ShipmentDate.Value.Date)
                 : 0;
 
             var remainingShipments = maxNumberOfShipments - currentNumberOfShipments;
-            var remainingActiveLoads = activeLoadsPermitted - currentActiveLoads;
-            var activeLoadsRemainingByDate = activeLoadsPermitted - futureActiveShipmentsByDate;
+            var activeLoadsRemainingByDate = activeLoadsPermitted - activeShipmentsByDate;
 
             return new RemainingShipmentsData
             {
                 ActiveLoadsPermitted = activeLoadsPermitted,
-                ActiveLoadsRemaining = remainingActiveLoads,
                 ActiveLoadsRemainingByDate = activeLoadsRemainingByDate,
                 ShipmentsRemaining = remainingShipments,
             };

--- a/src/EA.Iws.RequestHandlers/NotificationMovements/Create/GetRemainingShipmentsHandler.cs
+++ b/src/EA.Iws.RequestHandlers/NotificationMovements/Create/GetRemainingShipmentsHandler.cs
@@ -42,7 +42,7 @@
 
             var futureActiveShipmentsByDate = message.ShipmentDate.HasValue
                 ? (await movementRepository.GetFutureActiveMovements(message.NotificationId)).Count(
-                    m => m.Date == message.ShipmentDate.Value)
+                    m => m.Date.Date == message.ShipmentDate.Value.Date)
                 : 0;
 
             var remainingShipments = maxNumberOfShipments - currentNumberOfShipments;

--- a/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationMovements/CreateControllerTests.cs
+++ b/src/EA.Iws.Web.Tests.Unit/Controllers/NotificationMovements/CreateControllerTests.cs
@@ -60,7 +60,6 @@
             var remainingshipment = new RemainingShipmentsData
             {
                 ShipmentsRemaining = 400,
-                ActiveLoadsRemaining = 300,
                 ActiveLoadsPermitted = 300,
                 ActiveLoadsRemainingByDate = 100
             };
@@ -103,7 +102,6 @@
             var remainingshipment = new RemainingShipmentsData
             {
                 ShipmentsRemaining = 100,
-                ActiveLoadsRemaining = 20,
                 ActiveLoadsPermitted = 20,
                 ActiveLoadsRemainingByDate = 20
             };
@@ -140,7 +138,6 @@
             var remainingshipment = new RemainingShipmentsData
             {
                 ShipmentsRemaining = 100,
-                ActiveLoadsRemaining = 20,
                 ActiveLoadsPermitted = 20,
                 ActiveLoadsRemainingByDate = 20
             };
@@ -177,7 +174,6 @@
             var remainingshipment = new RemainingShipmentsData
             {
                 ShipmentsRemaining = 100,
-                ActiveLoadsRemaining = 20,
                 ActiveLoadsPermitted = 20,
                 ActiveLoadsRemainingByDate = 3
             };


### PR DESCRIPTION
PBI 69318
- Add `MovementStatus.New` and `MovementStatus.Captured` to count as an active movement.
- Updated the summary table to include this status.

Fixes bug - 69661

In the Movement repo, there was an existing active movement function where it would grab all movements based on their status and ensured that shipment date is in the past. This is no longer required. Updated the repo with a function to grab all active movements regardless of the date. It is then up to the consumer to handle the date as required.