### PR TITLE
Shipment audit search

### DIFF
--- a/src/EA.Iws.Core/Movement/MovementAuditType.cs
+++ b/src/EA.Iws.Core/Movement/MovementAuditType.cs
@@ -1,8 +1,11 @@
 ﻿namespace EA.Iws.Core.Movement
 {
+    using System.ComponentModel.DataAnnotations;
+
     public enum MovementAuditType
     {
         Prenotified = 1,
+        [Display(Name = "No prenotification received (internal user only change)")]
         NoPrenotificationReceived = 2,
         Received = 3,
         Recovered = 4,

--- a/src/EA.Iws.Core/Shared/ShipmentAuditRecord.cs
+++ b/src/EA.Iws.Core/Shared/ShipmentAuditRecord.cs
@@ -11,10 +11,10 @@
 
         public ShipmentAuditRecord(int shipmentNumber, MovementAuditType auditType, string userName,  DateTimeOffset dateAdded)
         {
-            this.UserName = userName;
-            this.ShipmentNumber = shipmentNumber;
-            this.AuditType = auditType;
-            this.DateAdded = dateAdded;
+            UserName = userName;
+            ShipmentNumber = shipmentNumber;
+            AuditType = auditType;
+            DateAdded = dateAdded;
         }
 
         public string UserName { get; set; }

--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportMovementAuditRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportMovementAuditRepository.cs
@@ -29,14 +29,21 @@
             await context.SaveChangesAsync();
         }
 
-        public async Task<IEnumerable<ImportMovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize)
+        public async Task<IEnumerable<ImportMovementAudit>> GetPagedShipmentAuditsById(Guid notificationId,
+            int pageNumber, int pageSize, int? shipmentNumber)
         {
-            return await this.context.ImportMovementAudits
-            .Where(p => p.NotificationId == notificationId)
-            .OrderByDescending(x => x.DateAdded)
-            .Skip((pageNumber - 1) * pageSize)
-            .Take(pageSize)
-            .ToArrayAsync();
+            var query = context.ImportMovementAudits
+                .Where(p => p.NotificationId == notificationId)
+                .OrderByDescending(x => x.DateAdded)
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize);
+
+            if (shipmentNumber.HasValue)
+            {
+                query = query.Where(m => m.ShipmentNumber == shipmentNumber.Value);
+            }
+
+            return await query.ToArrayAsync();
         }
 
         public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId)

--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportMovementAuditRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportMovementAuditRepository.cs
@@ -46,10 +46,16 @@
             return await query.ToArrayAsync();
         }
 
-        public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId)
+        public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId, int? shipmentNumber)
         {
-            return await context.ImportMovementAudits
-                .CountAsync(m => m.NotificationId == notificationId);
+            var query = context.ImportMovementAudits.Where(m => m.NotificationId == notificationId);
+
+            if (shipmentNumber.HasValue)
+            {
+                query = query.Where(m => m.ShipmentNumber == shipmentNumber.Value);
+            }
+
+            return await query.CountAsync();
         }
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationRepository.cs
@@ -103,6 +103,7 @@
                 DELETE FROM [ImportNotification].[WasteCode] WHERE WasteTypeId IN (SELECT [Id] FROM [ImportNotification].[WasteType] WHERE ImportNotificationId = @Id)
                 DELETE FROM [ImportNotification].[WasteType] WHERE ImportNotificationId = @Id
                 DELETE FROM [ImportNotification].[Withdrawn] WHERE NotificationId = @Id
+                DELETE FROM [ImportNotification].[MovementAudit] WHERE NotificationId = @Id
                 DELETE FROM [Draft].[Import] WHERE ImportNotificationId = @Id 
                 DELETE FROM [ImportNotification].[Notification] WHERE Id = @Id",
                 new SqlParameter("@Id", notificationId));

--- a/src/EA.Iws.DataAccess/Repositories/MovementAuditRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementAuditRepository.cs
@@ -31,14 +31,21 @@
             context.MovementAudits.Add(audit);
         }
 
-        public async Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize)
+        public async Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber,
+            int pageSize, int? shipmentNumber)
         {
-                return await this.context.MovementAudits
+            var query = context.MovementAudits
                 .Where(p => p.NotificationId == notificationId)
                 .OrderByDescending(x => x.DateAdded)
                 .Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToArrayAsync();
+                .Take(pageSize);
+
+            if (shipmentNumber.HasValue)
+            {
+                query = query.Where(m => m.ShipmentNumber == shipmentNumber.Value);
+            }
+
+            return await query.ToArrayAsync();
         }
 
         public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId)

--- a/src/EA.Iws.DataAccess/Repositories/MovementAuditRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/MovementAuditRepository.cs
@@ -48,10 +48,16 @@
             return await query.ToArrayAsync();
         }
 
-        public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId)
+        public async Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId, int? shipmentNumber)
         {
-            return await context.MovementAudits
-                .CountAsync(m => m.NotificationId == notificationId);
+            var query = context.MovementAudits.Where(m => m.NotificationId == notificationId);
+
+            if (shipmentNumber.HasValue)
+            {
+                query = query.Where(m => m.ShipmentNumber == shipmentNumber.Value);
+            }
+
+            return await query.CountAsync();
         }      
     }
 }

--- a/src/EA.Iws.DataAccess/Repositories/NotificationApplicationRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/NotificationApplicationRepository.cs
@@ -127,6 +127,7 @@
                 DELETE FROM [Notification].[SharedUser] WHERE NotificationId = @Id
                 DELETE FROM [Notification].[SharedUserHistory] WHERE NotificationId = @Id
                 DELETE FROM [Notification].[Audit] WHERE NotificationId = @Id
+                DELETE FROM [Notification].[MovementAudit] WHERE NotificationId = @Id
                 DELETE FROM [Notification].[Notification] WHERE Id = @Id",
                 new SqlParameter("@Id", notificationId));
 

--- a/src/EA.Iws.Domain/ImportMovement/IImportMovementAuditRepository.cs
+++ b/src/EA.Iws.Domain/ImportMovement/IImportMovementAuditRepository.cs
@@ -11,6 +11,6 @@
         Task<IEnumerable<ImportMovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber,
             int pageSize, int? shipmentNumber);
 
-        Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId);
+        Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId, int? shipmentNumber);
     }
 }

--- a/src/EA.Iws.Domain/ImportMovement/IImportMovementAuditRepository.cs
+++ b/src/EA.Iws.Domain/ImportMovement/IImportMovementAuditRepository.cs
@@ -8,7 +8,8 @@
     {
         Task Add(ImportMovementAudit audit);
 
-        Task<IEnumerable<ImportMovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize);
+        Task<IEnumerable<ImportMovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber,
+            int pageSize, int? shipmentNumber);
 
         Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId);
     }

--- a/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
+++ b/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
@@ -11,6 +11,6 @@
         Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize,
             int? shipmentNumber);
 
-        Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId);
+        Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId, int? shipmentNumber);
     }
 }

--- a/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
+++ b/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
@@ -8,7 +8,7 @@
     {
         Task Add(MovementAudit audit);
 
-        Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize);
+        Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize, int? shipmentNumber);
 
         Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId);
     }

--- a/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
+++ b/src/EA.Iws.Domain/Movement/IMovementAuditRepository.cs
@@ -8,7 +8,8 @@
     {
         Task Add(MovementAudit audit);
 
-        Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize, int? shipmentNumber);
+        Task<IEnumerable<MovementAudit>> GetPagedShipmentAuditsById(Guid notificationId, int pageNumber, int pageSize,
+            int? shipmentNumber);
 
         Task<int> GetTotalNumberOfShipmentAudits(Guid notificationId);
     }

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Movement\Complete\SaveMovementCompletedReceiptHandlerTests.cs" />
     <Compile Include="Movement\DoesQuantityReceivedExceedToleranceHandlerTests.cs" />
     <Compile Include="Movement\Edit\UpdateMovementDateHandlerTests.cs" />
+    <Compile Include="Movement\GetMovementAuditByNotificationIdHandlerTests.cs" />
     <Compile Include="Movement\GetSubmittedMovementsHandlerTests.cs" />
     <Compile Include="Movement\GetNotificationIdByMovementIdHandlerTests.cs" />
     <Compile Include="Movement\Receive\SetMovementAcceptedHandlerTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Copy\GetNotificationsToCopyForUserHandlerTests.cs" />
     <Compile Include="Helpers\TestDbSet.cs" />
     <Compile Include="Helpers\AddressDataEqualityComparer.cs" />
+    <Compile Include="ImportMovement\GetImportMovementAuditByNotificationIdHandlerTests.cs" />
     <Compile Include="ImportNotification\AddImportNotificationCommentsHandlerTests.cs" />
     <Compile Include="ImportNotification\DeleteImportNotificationCommentHandlerTest.cs" />
     <Compile Include="ImportNotification\Draft\TransitStateCollectionTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/ImportMovement/GetImportMovementAuditByNotificationIdHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/ImportMovement/GetImportMovementAuditByNotificationIdHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace EA.Iws.RequestHandlers.Tests.Unit.Movement
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.ImportMovement
 {
     using System;
     using System.Collections.Generic;
@@ -6,37 +6,37 @@
     using System.Threading.Tasks;
     using Core.Movement;
     using Core.Shared;
-    using Domain.Movement;
+    using Domain.ImportMovement;
     using FakeItEasy;
     using Prsd.Core;
     using Prsd.Core.Mapper;
-    using RequestHandlers.Movement;
-    using Requests.Movement;
+    using RequestHandlers.ImportMovement;
+    using Requests.ImportMovement;
     using Xunit;
 
-    public class GetMovementAuditByNotificationIdHandlerTests
+    public class GetImportMovementAuditByNotificationIdHandlerTests
     {
-        private readonly GetMovementAuditByNotificationIdHandler handler;
+        private readonly GetImportMovementAuditByNotificationIdHandler handler;
         private readonly IMapper mapper;
-        private readonly IMovementAuditRepository repository;
+        private readonly IImportMovementAuditRepository repository;
 
         private readonly Guid notificationId;
         private const int AuditCount = 10;
         private const int PageSize = 15;
         private const string AnyString = "test";
 
-        public GetMovementAuditByNotificationIdHandlerTests()
+        public GetImportMovementAuditByNotificationIdHandlerTests()
         {
             notificationId = Guid.NewGuid();
 
             mapper = A.Fake<IMapper>();
-            repository = A.Fake<IMovementAuditRepository>();
+            repository = A.Fake<IImportMovementAuditRepository>();
 
-            handler = new GetMovementAuditByNotificationIdHandler(mapper, repository);
+            handler = new GetImportMovementAuditByNotificationIdHandler(mapper, repository);
         }
 
         [Fact]
-        public async Task GetMovementAuditByNotificationIdHandler_GetPagedShipmentAuditsById()
+        public async Task GetImportMovementAuditByNotificationIdHandler_GetPagedShipmentAuditsById()
         {
             var request = GetRequest(1, 5);
 
@@ -47,26 +47,28 @@
         }
 
         [Fact]
-        public async Task GetMovementAuditByNotificationIdHandler_MapsToShipmentAudit()
+        public async Task GetImportMovementAuditByNotificationIdHandle_MapsToShipmentAudit()
         {
             var request = GetRequest(1, 5);
 
             await handler.HandleAsync(request);
 
             A.CallTo(
-                    () => mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(A<IEnumerable<MovementAudit>>.Ignored))
+                    () =>
+                        mapper.Map<IEnumerable<ImportMovementAudit>, ShipmentAuditData>(
+                            A<IEnumerable<ImportMovementAudit>>.Ignored))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
-        private GetMovementAuditByNotificationId GetRequest(int pageNumber, int? shipmentNumber)
+        private GetImportMovementAuditByNotificationId GetRequest(int pageNumber, int? shipmentNumber)
         {
             SetAuditData(pageNumber, shipmentNumber);
-            return new GetMovementAuditByNotificationId(notificationId, pageNumber, shipmentNumber);
+            return new GetImportMovementAuditByNotificationId(notificationId, pageNumber, shipmentNumber);
         }
 
         private void SetAuditData(int pageNumber, int? shipmentNumber)
         {
-            var audits = new List<MovementAudit>();
+            var audits = new List<ImportMovementAudit>();
 
             var auditTypeValues = Enum.GetValues(typeof(MovementAuditType));
             var random = new Random();
@@ -76,7 +78,7 @@
                 var number = shipmentNumber.HasValue ? shipmentNumber.Value : i + 1;
                 var auditType = (MovementAuditType)auditTypeValues.GetValue(random.Next(auditTypeValues.Length));
 
-                audits.Add(new MovementAudit(notificationId, number, AnyString, (int)auditType,
+                audits.Add(new ImportMovementAudit(notificationId, number, AnyString, (int)auditType,
                     SystemTime.UtcNow));
             }
 
@@ -85,7 +87,7 @@
             A.CallTo(() => repository.GetPagedShipmentAuditsById(notificationId, pageNumber, PageSize, shipmentNumber)).Returns(audits);
         }
 
-        private void SetMapper(IEnumerable<MovementAudit> movementAudits)
+        private void SetMapper(IEnumerable<ImportMovementAudit> movementAudits)
         {
             var data = new ShipmentAuditData
             {
@@ -97,7 +99,7 @@
             };
 
             A.CallTo(
-                    () => mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(A<IEnumerable<MovementAudit>>.Ignored))
+                    () => mapper.Map<IEnumerable<ImportMovementAudit>, ShipmentAuditData>(A<IEnumerable<ImportMovementAudit>>.Ignored))
                 .Returns(data);
         }
     }

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/Movement/GetMovementAuditByNotificationIdHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/Movement/GetMovementAuditByNotificationIdHandlerTests.cs
@@ -1,0 +1,106 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.Movement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Core.Movement;
+    using Core.Shared;
+    using Domain.Movement;
+    using FakeItEasy;
+    using Prsd.Core;
+    using Prsd.Core.Mapper;
+    using RequestHandlers.Movement;
+    using Requests.Movement;
+    using Xunit;
+
+    public class GetMovementAuditByNotificationIdHandlerTests
+    {
+        private readonly GetMovementAuditByNotificationIdHandler handler;
+        private readonly IMapper mapper;
+        private readonly IMovementAuditRepository repository;
+
+        private readonly Guid notificationId;
+        private const int AuditCount = 10;
+        private const int PageSize = 15;
+        private const string AnyString = "test";
+
+        public GetMovementAuditByNotificationIdHandlerTests()
+        {
+            notificationId = Guid.NewGuid();
+
+            mapper = A.Fake<IMapper>();
+            repository = A.Fake<IMovementAuditRepository>();
+
+            A.CallTo(() => repository.GetTotalNumberOfShipmentAudits(notificationId)).Returns(AuditCount);
+
+            handler = new GetMovementAuditByNotificationIdHandler(mapper, repository);
+        }
+
+        [Fact]
+        public async Task GetMovementAuditByNotificationIdHandler_GetPagedShipmentAuditsById()
+        {
+            var request = GetRequest(1, 5);
+
+            await handler.HandleAsync(request);
+
+            A.CallTo(() => repository.GetPagedShipmentAuditsById(notificationId, 1, PageSize, request.ShipmentNumber))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public async Task GetMovementAuditByNotificationIdHandler_MapsToShipmentAudit()
+        {
+            var request = GetRequest(1, 5);
+
+            await handler.HandleAsync(request);
+
+            A.CallTo(
+                    () => mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(A<IEnumerable<MovementAudit>>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        private GetMovementAuditByNotificationId GetRequest(int pageNumber, int? shipmentNumber)
+        {
+            SetAuditData(pageNumber, shipmentNumber);
+            return new GetMovementAuditByNotificationId(notificationId, pageNumber, shipmentNumber);
+        }
+
+        private void SetAuditData(int pageNumber, int? shipmentNumber)
+        {
+            var audits = new List<MovementAudit>();
+
+            var auditTypeValues = Enum.GetValues(typeof(MovementAuditType));
+            var random = new Random();
+
+            for (var i = 0; i < AuditCount; i++)
+            {
+                var number = shipmentNumber.HasValue ? shipmentNumber.Value : i + 1;
+                var auditType = (MovementAuditType)auditTypeValues.GetValue(random.Next(auditTypeValues.Length));
+
+                audits.Add(new MovementAudit(notificationId, number, AnyString, (int)auditType,
+                    SystemTime.UtcNow));
+            }
+
+            SetMapper(audits);
+
+            A.CallTo(() => repository.GetPagedShipmentAuditsById(notificationId, pageNumber, PageSize, shipmentNumber)).Returns(audits);
+        }
+
+        private void SetMapper(IEnumerable<MovementAudit> movementAudits)
+        {
+            var data = new ShipmentAuditData
+            {
+                TableData = movementAudits
+                    .Select(shipmentAudit => mapper.Map<ShipmentAuditRecord>(shipmentAudit))
+                    .OrderByDescending(x => x.ShipmentNumber)
+                    .ThenByDescending(x => x.DateAdded)
+                    .ToList()
+            };
+
+            A.CallTo(
+                    () => mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(A<IEnumerable<MovementAudit>>.Ignored))
+                .Returns(data);
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace EA.Iws.RequestHandlers.ImportMovement
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Core.Shared;
     using DataAccess;
@@ -10,27 +11,27 @@
     using Requests.ImportMovement;
     internal class GetImportMovementAuditByNotificationIdHandler : IRequestHandler<GetImportMovementAuditByNotificationId, ShipmentAuditData>
     {
-        private readonly IwsContext context;
         private readonly IMapper mapper;
         private readonly IImportMovementAuditRepository repository;
         private const int PageSize = 15;
 
-        public GetImportMovementAuditByNotificationIdHandler(IwsContext context, IMapper mapper,
-          IImportMovementAuditRepository repository)
+        public GetImportMovementAuditByNotificationIdHandler(IMapper mapper,
+            IImportMovementAuditRepository repository)
         {
-            this.context = context;
             this.mapper = mapper;
             this.repository = repository;
         }
 
         public async Task<ShipmentAuditData> HandleAsync(GetImportMovementAuditByNotificationId message)
         {
-            IEnumerable<ImportMovementAudit> notificationAudits = await repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize);
+            var notificationAudits =
+                (await repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize))
+                    .ToList();
 
             var movementAuditTable = mapper.Map<IEnumerable<ImportMovementAudit>, ShipmentAuditData>(notificationAudits);
             movementAuditTable.PageNumber = message.PageNumber;
             movementAuditTable.PageSize = PageSize;
-            movementAuditTable.NumberOfShipmentAudits = await repository.GetTotalNumberOfShipmentAudits(message.NotificationId);
+            movementAuditTable.NumberOfShipmentAudits = notificationAudits.Count;
 
             return movementAuditTable;
         }

--- a/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
@@ -4,11 +4,11 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Core.Shared;
-    using DataAccess;
     using Domain.ImportMovement;
     using Prsd.Core.Mapper;
     using Prsd.Core.Mediator;
     using Requests.ImportMovement;
+
     internal class GetImportMovementAuditByNotificationIdHandler : IRequestHandler<GetImportMovementAuditByNotificationId, ShipmentAuditData>
     {
         private readonly IMapper mapper;
@@ -25,7 +25,9 @@
         public async Task<ShipmentAuditData> HandleAsync(GetImportMovementAuditByNotificationId message)
         {
             var notificationAudits =
-                (await repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize))
+                (await
+                        repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize,
+                            message.ShipmentNumber))
                     .ToList();
 
             var movementAuditTable = mapper.Map<IEnumerable<ImportMovementAudit>, ShipmentAuditData>(notificationAudits);

--- a/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/ImportMovement/GetImportMovementAuditByNotificationIdHandler.cs
@@ -33,7 +33,8 @@
             var movementAuditTable = mapper.Map<IEnumerable<ImportMovementAudit>, ShipmentAuditData>(notificationAudits);
             movementAuditTable.PageNumber = message.PageNumber;
             movementAuditTable.PageSize = PageSize;
-            movementAuditTable.NumberOfShipmentAudits = notificationAudits.Count;
+            movementAuditTable.NumberOfShipmentAudits =
+                await repository.GetTotalNumberOfShipmentAudits(message.NotificationId, message.ShipmentNumber);
 
             return movementAuditTable;
         }

--- a/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Core.Shared;
-    using DataAccess;
     using Domain.Movement;
     using Prsd.Core.Mapper;
     using Prsd.Core.Mediator;

--- a/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace EA.Iws.RequestHandlers.Movement
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Core.Shared;
     using DataAccess;
@@ -24,14 +25,14 @@
         public async Task<ShipmentAuditData> HandleAsync(GetMovementAuditByNotificationId message)
         {
             var notificationAudits =
-                await
+                (await
                     repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize,
-                        message.ShipmentNumber);
+                        message.ShipmentNumber)).ToList();
 
             var movementAuditTable = mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(notificationAudits);
             movementAuditTable.PageNumber = message.PageNumber;
             movementAuditTable.PageSize = PageSize;
-            movementAuditTable.NumberOfShipmentAudits = await repository.GetTotalNumberOfShipmentAudits(message.NotificationId);
+            movementAuditTable.NumberOfShipmentAudits = notificationAudits.Count;
 
             return movementAuditTable;
         }

--- a/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
@@ -31,7 +31,8 @@
             var movementAuditTable = mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(notificationAudits);
             movementAuditTable.PageNumber = message.PageNumber;
             movementAuditTable.PageSize = PageSize;
-            movementAuditTable.NumberOfShipmentAudits = notificationAudits.Count;
+            movementAuditTable.NumberOfShipmentAudits =
+                await repository.GetTotalNumberOfShipmentAudits(message.NotificationId, message.ShipmentNumber);
 
             return movementAuditTable;
         }

--- a/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Movement/GetMovementAuditByNotificationIdHandler.cs
@@ -11,22 +11,22 @@
 
     internal class GetMovementAuditByNotificationIdHandler : IRequestHandler<GetMovementAuditByNotificationId, ShipmentAuditData>
     {
-        private readonly IwsContext context;
         private readonly IMapper mapper;
         private readonly IMovementAuditRepository repository;
         private const int PageSize = 15;
 
-        public GetMovementAuditByNotificationIdHandler(IwsContext context, IMapper mapper,
-          IMovementAuditRepository repository)
+        public GetMovementAuditByNotificationIdHandler(IMapper mapper, IMovementAuditRepository repository)
         {
-            this.context = context;
             this.mapper = mapper;
             this.repository = repository;
         }
 
         public async Task<ShipmentAuditData> HandleAsync(GetMovementAuditByNotificationId message)
         {
-            IEnumerable<MovementAudit> notificationAudits = await repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize);
+            var notificationAudits =
+                await
+                    repository.GetPagedShipmentAuditsById(message.NotificationId, message.PageNumber, PageSize,
+                        message.ShipmentNumber);
 
             var movementAuditTable = mapper.Map<IEnumerable<MovementAudit>, ShipmentAuditData>(notificationAudits);
             movementAuditTable.PageNumber = message.PageNumber;

--- a/src/EA.Iws.Requests/ImportMovement/GetImportMovementAuditByNotificationId.cs
+++ b/src/EA.Iws.Requests/ImportMovement/GetImportMovementAuditByNotificationId.cs
@@ -13,10 +13,13 @@
 
         public int PageNumber { get; private set; }
 
-        public GetImportMovementAuditByNotificationId(Guid notificationId, int pageNumber)
+        public int? ShipmentNumber { get; private set; }
+
+        public GetImportMovementAuditByNotificationId(Guid notificationId, int pageNumber, int? shipmentNumber = null)
         {
-            this.NotificationId = notificationId;
-            this.PageNumber = pageNumber;
+            NotificationId = notificationId;
+            PageNumber = pageNumber;
+            ShipmentNumber = shipmentNumber;
         }
     }
 }

--- a/src/EA.Iws.Requests/Movement/GetMovementAuditByNotificationId.cs
+++ b/src/EA.Iws.Requests/Movement/GetMovementAuditByNotificationId.cs
@@ -13,10 +13,13 @@
 
         public int PageNumber { get; private set; }
 
-        public GetMovementAuditByNotificationId(Guid notificationId, int pageNumber)
+        public int? ShipmentNumber { get; private set; }
+
+        public GetMovementAuditByNotificationId(Guid notificationId, int pageNumber, int? shipmentNumber = null)
         {
-            this.NotificationId = notificationId;
-            this.PageNumber = pageNumber;
+            NotificationId = notificationId;
+            PageNumber = pageNumber;
+            ShipmentNumber = shipmentNumber;
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
@@ -8,6 +8,7 @@
     using Requests.Movement;
     using Requests.Notification;
     using ViewModels.ShipmentAudit;
+    using Web.ViewModels;
 
     [AuthorizeActivity(typeof(GetMovementAuditByNotificationId))]
     public class ShipmentAuditController : Controller
@@ -20,13 +21,42 @@
         }
 
         [HttpGet]
-        public async Task<ActionResult> Index(Guid id, int page = 1)
+        public async Task<ActionResult> Index(Guid id, ShipmentAuditFilterType? filter, int? number = null, int page = 1)
         {
             var response = await mediator.SendAsync(new GetMovementAuditByNotificationId(id, page));
-            var model = new ShipmentAuditViewModel(response);
-            model.NotificationId = id;
-            model.NotificationNumber = await mediator.SendAsync(new GetNotificationNumber(id));
+            var model = new ShipmentAuditViewModel(response)
+            {
+                NotificationId = id,
+                SelectedFilter = filter,
+                NotificationNumber = await mediator.SendAsync(new GetNotificationNumber(id))
+            };
+
             return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> Index(Guid id, ShipmentAuditViewModel model)
+        {
+            if (model.SelectedFilter == null)
+            {
+                return RedirectToAction("Index");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                var selectedFilter = model.SelectedFilter;
+                var response = await mediator.SendAsync(new GetMovementAuditByNotificationId(id, 1));
+                model = new ShipmentAuditViewModel(response)
+                {
+                    NotificationId = id,
+                    SelectedFilter = selectedFilter,
+                    NotificationNumber = await mediator.SendAsync(new GetNotificationNumber(id))
+                };
+                return View(model);
+            }
+
+            return RedirectToAction("Index", new { id = id, filter = model.SelectedFilter, number = model.ShipmentNumber, page = 1 });
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
@@ -23,11 +23,15 @@
         [HttpGet]
         public async Task<ActionResult> Index(Guid id, ShipmentAuditFilterType? filter, int? number = null, int page = 1)
         {
+            number = filter.HasValue && filter == ShipmentAuditFilterType.ShipmentNumber ? number : null;
+
             var response = await mediator.SendAsync(new GetMovementAuditByNotificationId(id, page, number));
+
             var model = new ShipmentAuditViewModel(response)
             {
                 NotificationId = id,
                 SelectedFilter = filter,
+                ShipmentNumberSearch = number.HasValue ? number.ToString() : null,
                 NotificationNumber = await mediator.SendAsync(new GetNotificationNumber(id))
             };
 

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Controllers/ShipmentAuditController.cs
@@ -23,7 +23,7 @@
         [HttpGet]
         public async Task<ActionResult> Index(Guid id, ShipmentAuditFilterType? filter, int? number = null, int page = 1)
         {
-            var response = await mediator.SendAsync(new GetMovementAuditByNotificationId(id, page));
+            var response = await mediator.SendAsync(new GetMovementAuditByNotificationId(id, page, number));
             var model = new ShipmentAuditViewModel(response)
             {
                 NotificationId = id,

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
@@ -30,13 +30,12 @@
         [Display(Name = "Shipment Number")]
         public string ShipmentNumberSearch { get; set; }
 
-        public int ShipmentNumber
+        public int? ShipmentNumber
         {
             get
             {
-                int result;
-                int.TryParse(ShipmentNumberSearch, out result);
-                return result;
+                int value;
+                return int.TryParse(ShipmentNumberSearch, out value) ? (int?)value : null;
             }
         }
 
@@ -75,7 +74,10 @@
         {
             if (SelectedFilter == ShipmentAuditFilterType.ShipmentNumber)
             {
-                if (string.IsNullOrEmpty(ShipmentNumberSearch) || ShipmentNumberSearch.Length > 6 || ShipmentNumber < 1)
+                if (string.IsNullOrEmpty(ShipmentNumberSearch) || 
+                    ShipmentNumberSearch.Length > 6 ||
+                    !ShipmentNumber.HasValue || 
+                    ShipmentNumber.Value < 1)
                 {
                     yield return new ValidationResult("Enter a valid shipment number", new[] { "ShipmentNumberSearch" });
                 }

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
@@ -1,15 +1,60 @@
 ﻿namespace EA.Iws.Web.Areas.AdminExportNotificationMovements.ViewModels.ShipmentAudit
 {
     using System;
-    using EA.Iws.Core.Shared;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Web.Mvc;
+    using Core.Shared;
+    using Prsd.Core.Helpers;
+    using Web.ViewModels;
     using Web.ViewModels.Shared;
 
-    public class ShipmentAuditViewModel
+    public class ShipmentAuditViewModel : IValidatableObject
     {
         public Guid NotificationId { get; set; }
 
         public string NotificationNumber { get; set; }
+
         public ShipmentAuditTrailViewModel ShipmentAuditModel { get; set; }
+
+        public int NumberOfShipmentAudits { get; set; }
+
+        public ShipmentAuditFilterType? SelectedFilter { get; set; }
+
+        [Display(Name = "Shipment Number")]
+        public string ShipmentNumberSearch { get; set; }
+
+        public int ShipmentNumber
+        {
+            get
+            {
+                int result;
+                int.TryParse(ShipmentNumberSearch, out result);
+                return result;
+            }
+        }
+
+        public SelectList FilterTerms
+        {
+            get
+            {
+                var filters =
+                    Enum.GetValues(typeof(ShipmentAuditFilterType))
+                        .Cast<ShipmentAuditFilterType>()
+                        .Select(
+                            s => new SelectListItem
+                            {
+                                Text = EnumHelper.GetDisplayName(s),
+                                Value = ((int)s).ToString()
+                            })
+                        .ToList();
+
+                filters.Insert(0, new SelectListItem { Text = "View all", Value = "-1" });
+
+                return new SelectList(filters, "Value", "Text", SelectedFilter);
+            }
+        }
 
         public ShipmentAuditViewModel()
         {
@@ -19,6 +64,17 @@
         public ShipmentAuditViewModel(ShipmentAuditData data)
         {
             ShipmentAuditModel = new ShipmentAuditTrailViewModel(data);
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (SelectedFilter == ShipmentAuditFilterType.ShipmentNumber)
+            {
+                if (string.IsNullOrEmpty(ShipmentNumberSearch) || ShipmentNumberSearch.Length > 6 || ShipmentNumber < 1)
+                {
+                    yield return new ValidationResult("Enter a valid shipment number", new[] { "ShipmentNumberSearch" });
+                }
+            }
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
@@ -20,6 +20,11 @@
 
         public int NumberOfShipmentAudits { get; set; }
 
+        public bool DisplayFilter
+        {
+            get { return (SelectedFilter.HasValue || ShipmentAuditModel.NumberOfShipmentAudits > 0); }
+        }
+
         public ShipmentAuditFilterType? SelectedFilter { get; set; }
 
         [Display(Name = "Shipment Number")]

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -16,7 +16,7 @@
         <div class="column-two-thirds">
             @using (Html.BeginForm("Index", "ShipmentAudit", FormMethod.Post, new { id = "searchForm" }))
             {
-                @Html.AntiForgeryToken();
+                @Html.AntiForgeryToken()
                 @Html.Gds().ValidationSummary()
                 @Html.HiddenFor(m => m.NotificationId)
 

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -9,7 +9,8 @@
     <h1 class="heading-large">@string.Format("Shipment changes for Notification {0}", Model.NotificationNumber) </h1>
     <p>The type of changes reflect changes made by all users.</p>
 </header>
-@if (Model.ShipmentAuditModel.ShipmentAuditItems.Any())
+
+@if (Model.DisplayFilter)
 {
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -1,14 +1,75 @@
-﻿@using Resource = EA.Iws.Web.Areas.AdminExportNotificationMovements.Views.ShipmentAudit.IndexResources
+﻿@using EA.Iws.Web.ViewModels
+@using Resource = EA.Iws.Web.Areas.AdminExportNotificationMovements.Views.ShipmentAudit.IndexResources
 @using EA.Iws.Web.Views.Shared
 @model EA.Iws.Web.Areas.AdminExportNotificationMovements.ViewModels.ShipmentAudit.ShipmentAuditViewModel
 @{
 	ViewBag.Title = "Audit trail shipments";
 }
 <header class="hgroup">
-	<h1 class="heading-large">@string.Format("Shipment changes for Notification {0}", Model.NotificationNumber) </h1>
-	<p>The type of changes reflect changes made by all users.</p>
+    <h1 class="heading-large">@string.Format("Shipment changes for Notification {0}", Model.NotificationNumber) </h1>
+    <p>The type of changes reflect changes made by all users.</p>
 </header>
+@if (Model.ShipmentAuditModel.ShipmentAuditItems.Any())
+{
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            @using (Html.BeginForm("Index", "ShipmentAudit", FormMethod.Post, new { id = "searchForm" }))
+            {
+                @Html.AntiForgeryToken();
+                @Html.Gds().ValidationSummary()
+                @Html.HiddenFor(m => m.NotificationId)
+
+                <div>
+                    @Resource.FilterBy
+                </div>
+                <div>
+                    @Html.Gds().DropDownListFor(m => m.SelectedFilter, Model.FilterTerms, new { @id = "filterSelectList" })
+                </div>
+
+                <br />
+
+                <div class="@(Model.SelectedFilter.HasValue && Model.SelectedFilter.Value == ShipmentAuditFilterType.ShipmentNumber ? string.Empty : "hidden")" id="shipmentSection">
+                    <div class="form-group @Html.Gds().FormGroupClass(m => m.ShipmentNumberSearch)">
+                        <div>
+                            @Html.Gds().LabelFor(m => m.ShipmentNumberSearch, false)
+                        </div>
+                        <div>
+                            @Html.Gds().ValidationMessageFor(m => m.ShipmentNumberSearch)
+                            @Html.Gds().TextBoxFor(m => m.ShipmentNumberSearch)
+                        </div>
+                        <br />
+                        <div class="form-group">
+                            <button class="button" type="submit" name="command" value="search">@Resource.Search</button>
+                        </div>
+                    </div>
+                    <br />
+                </div>
+            }
+        </div>
+    </div>
+}
+
+<br />
+
 @Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel)
 <div class="form-group">
-	@Html.ActionLink(@Resource.OverviewLink, "Index", "Home", new { area = "AdminExportAssessment", id = Model.NotificationId }, null)
+    @Html.ActionLink(@Resource.OverviewLink, "Index", "Home", new { area = "AdminExportAssessment", id = Model.NotificationId }, null)
 </div>
+
+@section scripts {
+    <script>
+        $(function () {
+            $('select#filterSelectList').change(function () {
+                var selectedValue = $(this).val();
+                var shipmentSection = $("#shipmentSection");
+                var shipmentFilter = @(((int)ShipmentAuditFilterType.ShipmentNumber).ToString());
+
+                if (selectedValue == shipmentFilter) {
+                    shipmentSection.removeClass('hidden');
+                } else {
+                    $("#searchForm").submit();
+                }
+            });
+        });
+    </script>
+}

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -52,7 +52,8 @@
 
 <br />
 
-@Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel)
+@Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel, new ViewDataDictionary() { { "Filter", Model.SelectedFilter }, { "ShipmentNumber", Model.ShipmentNumber } })
+
 <div class="form-group">
     @Html.ActionLink(@Resource.OverviewLink, "Index", "Home", new { area = "AdminExportAssessment", id = Model.NotificationId }, null)
 </div>

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/IndexResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/IndexResources.Designer.cs
@@ -62,6 +62,15 @@ namespace EA.Iws.Web.Areas.AdminExportNotificationMovements.Views.ShipmentAudit 
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filter by:.
+        /// </summary>
+        public static string FilterBy {
+            get {
+                return ResourceManager.GetString("FilterBy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type of changes reflect changes made by all users..
         /// </summary>
         public static string InfoText {

--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/IndexResources.resx
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/ShipmentAudit/IndexResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FilterBy" xml:space="preserve">
+    <value>Filter by:</value>
+  </data>
   <data name="InfoText" xml:space="preserve">
     <value>The type of changes reflect changes made by all users.</value>
   </data>

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Controllers/ShipmentAuditController.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Controllers/ShipmentAuditController.cs
@@ -23,7 +23,7 @@
         [HttpGet]
         public async Task<ActionResult> Index(Guid id, ShipmentAuditFilterType? filter, int? number = null, int page = 1)
         {
-            var response = await mediator.SendAsync(new GetImportMovementAuditByNotificationId(id, page));
+            var response = await mediator.SendAsync(new GetImportMovementAuditByNotificationId(id, page, number));
             var model = new ShipmentAuditViewModel(response)
             {
                 NotificationId = id,

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Controllers/ShipmentAuditController.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Controllers/ShipmentAuditController.cs
@@ -23,11 +23,15 @@
         [HttpGet]
         public async Task<ActionResult> Index(Guid id, ShipmentAuditFilterType? filter, int? number = null, int page = 1)
         {
+            number = filter.HasValue && filter == ShipmentAuditFilterType.ShipmentNumber ? number : null;
+
             var response = await mediator.SendAsync(new GetImportMovementAuditByNotificationId(id, page, number));
+
             var model = new ShipmentAuditViewModel(response)
             {
                 NotificationId = id,
                 SelectedFilter = filter,
+                ShipmentNumberSearch = number.HasValue ? number.ToString() : null,
                 NotificationNumber = await mediator.SendAsync(new GetImportNotificationNumberById(id))
             };
 

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
@@ -30,13 +30,12 @@
         [Display(Name = "Shipment Number")]
         public string ShipmentNumberSearch { get; set; }
 
-        public int ShipmentNumber
+        public int? ShipmentNumber
         {
             get
             {
-                int result;
-                int.TryParse(ShipmentNumberSearch, out result);
-                return result;
+                int value;
+                return int.TryParse(ShipmentNumberSearch, out value) ? (int?)value : null;
             }
         }
 
@@ -75,7 +74,10 @@
         {
             if (SelectedFilter == ShipmentAuditFilterType.ShipmentNumber)
             {
-                if (string.IsNullOrEmpty(ShipmentNumberSearch) || ShipmentNumberSearch.Length > 6 || ShipmentNumber < 1)
+                if (string.IsNullOrEmpty(ShipmentNumberSearch) ||
+                    ShipmentNumberSearch.Length > 6 ||
+                    !ShipmentNumber.HasValue ||
+                    ShipmentNumber.Value < 1)
                 {
                     yield return new ValidationResult("Enter a valid shipment number", new[] { "ShipmentNumberSearch" });
                 }

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/ViewModels/ShipmentAudit/ShipmentAuditViewModel.cs
@@ -1,16 +1,65 @@
 ﻿namespace EA.Iws.Web.Areas.AdminImportNotificationMovements.ViewModels.ShipmentAudit
 {
     using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using System.Web.Mvc;
     using EA.Iws.Core.Shared;
+    using Prsd.Core.Helpers;
+    using Web.ViewModels;
     using Web.ViewModels.Shared;
 
-    public class ShipmentAuditViewModel
+    public class ShipmentAuditViewModel : IValidatableObject
     {
         public Guid NotificationId { get; set; }
 
         public string NotificationNumber { get; set; }
 
         public ShipmentAuditTrailViewModel ShipmentAuditModel { get; set; }
+
+        public int NumberOfShipmentAudits { get; set; }
+
+        public bool DisplayFilter
+        {
+            get { return (SelectedFilter.HasValue || ShipmentAuditModel.NumberOfShipmentAudits > 0); }
+        }
+
+        public ShipmentAuditFilterType? SelectedFilter { get; set; }
+
+        [Display(Name = "Shipment Number")]
+        public string ShipmentNumberSearch { get; set; }
+
+        public int ShipmentNumber
+        {
+            get
+            {
+                int result;
+                int.TryParse(ShipmentNumberSearch, out result);
+                return result;
+            }
+        }
+
+        public SelectList FilterTerms
+        {
+            get
+            {
+                var filters =
+                    Enum.GetValues(typeof(ShipmentAuditFilterType))
+                        .Cast<ShipmentAuditFilterType>()
+                        .Select(
+                            s => new SelectListItem
+                            {
+                                Text = EnumHelper.GetDisplayName(s),
+                                Value = ((int)s).ToString()
+                            })
+                        .ToList();
+
+                filters.Insert(0, new SelectListItem { Text = "View all", Value = "-1" });
+
+                return new SelectList(filters, "Value", "Text", SelectedFilter);
+            }
+        }
 
         public ShipmentAuditViewModel()
         {
@@ -20,6 +69,17 @@
         public ShipmentAuditViewModel(ShipmentAuditData data)
         {
             ShipmentAuditModel = new ShipmentAuditTrailViewModel(data);
+        }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (SelectedFilter == ShipmentAuditFilterType.ShipmentNumber)
+            {
+                if (string.IsNullOrEmpty(ShipmentNumberSearch) || ShipmentNumberSearch.Length > 6 || ShipmentNumber < 1)
+                {
+                    yield return new ValidationResult("Enter a valid shipment number", new[] { "ShipmentNumberSearch" });
+                }
+            }
         }
     }
 }

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -1,14 +1,76 @@
-﻿@using EA.Iws.Web.Views.Shared
+﻿@using EA.Iws.Web.ViewModels
+@using EA.Iws.Web.Views.Shared
 
 @model EA.Iws.Web.Areas.AdminImportNotificationMovements.ViewModels.ShipmentAudit.ShipmentAuditViewModel
 @{
 	ViewBag.Title = "Audit trail shipments";
 }
 <header class="hgroup">
-	<h1 class="heading-large">@string.Format("Shipment changes for Notification {0}", Model.NotificationNumber) </h1>
-	<p>The type of changes reflect changes made by all users.</p>
+    <h1 class="heading-large">@string.Format("Shipment changes for Notification {0}", Model.NotificationNumber) </h1>
+    <p>The type of changes reflect changes made by all users.</p>
 </header>
+
+@if (Model.DisplayFilter)
+{
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            @using (Html.BeginForm("Index", "ShipmentAudit", FormMethod.Post, new { id = "searchForm" }))
+            {
+                @Html.AntiForgeryToken()
+                ;
+                @Html.Gds().ValidationSummary()
+                @Html.HiddenFor(m => m.NotificationId)
+
+                <div>
+                    Filter by:
+                </div>
+                <div>
+                    @Html.Gds().DropDownListFor(m => m.SelectedFilter, Model.FilterTerms, new { @id = "filterSelectList" })
+                </div>
+
+                <br/>
+
+                <div class="@(Model.SelectedFilter.HasValue && Model.SelectedFilter.Value == ShipmentAuditFilterType.ShipmentNumber ? string.Empty : "hidden")" id="shipmentSection">
+                    <div class="form-group @Html.Gds().FormGroupClass(m => m.ShipmentNumberSearch)">
+                        <div>
+                            @Html.Gds().LabelFor(m => m.ShipmentNumberSearch, false)
+                        </div>
+                        <div>
+                            @Html.Gds().ValidationMessageFor(m => m.ShipmentNumberSearch)
+                            @Html.Gds().TextBoxFor(m => m.ShipmentNumberSearch)
+                        </div>
+                        <br/>
+                        <div class="form-group">
+                            <button class="button" type="submit" name="command" value="search">Search</button>
+                        </div>
+                    </div>
+                    <br/>
+                </div>
+            }
+        </div>
+    </div>
+}
+<br />
+
 @Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel)
 <div class="form-group">
-	@Html.ActionLink("Go to Notification Overview", "Index", "Home", new { area = "ImportNotification", id = Model.NotificationId }, null)
+    @Html.ActionLink("Go to Notification Overview", "Index", "Home", new { area = "ImportNotification", id = Model.NotificationId }, null)
 </div>
+
+@section scripts {
+    <script>
+        $(function () {
+            $('select#filterSelectList').change(function () {
+                var selectedValue = $(this).val();
+                var shipmentSection = $("#shipmentSection");
+                var shipmentFilter = @(((int)ShipmentAuditFilterType.ShipmentNumber).ToString());
+
+                if (selectedValue == shipmentFilter) {
+                    shipmentSection.removeClass('hidden');
+                } else {
+                    $("#searchForm").submit();
+                }
+            });
+        });
+    </script>
+}

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -17,7 +17,6 @@
             @using (Html.BeginForm("Index", "ShipmentAudit", FormMethod.Post, new { id = "searchForm" }))
             {
                 @Html.AntiForgeryToken()
-                ;
                 @Html.Gds().ValidationSummary()
                 @Html.HiddenFor(m => m.NotificationId)
 

--- a/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminImportNotificationMovements/Views/ShipmentAudit/Index.cshtml
@@ -51,7 +51,8 @@
 }
 <br />
 
-@Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel)
+@Html.Partial("_ShipmentAudit", Model.ShipmentAuditModel, new ViewDataDictionary() { { "Filter", Model.SelectedFilter }, { "ShipmentNumber", Model.ShipmentNumber } })
+
 <div class="form-group">
     @Html.ActionLink("Go to Notification Overview", "Index", "Home", new { area = "ImportNotification", id = Model.NotificationId }, null)
 </div>

--- a/src/EA.Iws.Web/EA.Iws.Web.csproj
+++ b/src/EA.Iws.Web/EA.Iws.Web.csproj
@@ -3542,6 +3542,7 @@
     <Compile Include="Areas\NotificationApplication\ViewModels\ShareNotification\SharedUserListConfirmViewModel.cs" />
     <Compile Include="Areas\NotificationApplication\ViewModels\ShareNotification\SharedUserListViewModel.cs" />
     <Compile Include="Areas\NotificationApplication\ViewModels\ShareNotification\ShareNotificationViewModel.cs" />
+    <Compile Include="ViewModels\ShipmentAuditFilterType.cs" />
     <Compile Include="Views\Account\EmailVerificationRequiredResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/EA.Iws.Web/ViewModels/Shared/ShipmentAuditTrailViewModel.cs
+++ b/src/EA.Iws.Web/ViewModels/Shared/ShipmentAuditTrailViewModel.cs
@@ -21,7 +21,7 @@
         public ShipmentAuditTrailViewModel(ShipmentAuditData data)
         {
             ShipmentAuditItems = new List<ShipmentAuditRecord>();
-            foreach (ShipmentAuditRecord shipmentAudit in data.TableData)
+            foreach (var shipmentAudit in data.TableData)
             {
                 ShipmentAuditItems.Add(shipmentAudit);
             }

--- a/src/EA.Iws.Web/ViewModels/ShipmentAuditFilterType.cs
+++ b/src/EA.Iws.Web/ViewModels/ShipmentAuditFilterType.cs
@@ -1,0 +1,10 @@
+﻿namespace EA.Iws.Web.ViewModels
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public enum ShipmentAuditFilterType
+    {
+        [Display(Name = "Shipment Number")]
+        ShipmentNumber
+    }
+}

--- a/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
+++ b/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
@@ -1,4 +1,5 @@
 ﻿@using EA.Iws.Web.Infrastructure.Paging
+@using EnumHelper = EA.Prsd.Core.Helpers.EnumHelper
 @model EA.Iws.Web.ViewModels.Shared.ShipmentAuditTrailViewModel
 @helper DisplayDate(DateTimeOffset date)
 {
@@ -36,26 +37,26 @@
 			</thead>
 
 			<tbody>
-				@for (int i = 0; i < Model.ShipmentAuditItems.Count; i++)
-				{
-					<tr>
-						<td>
-							@Model.ShipmentAuditItems[i].ShipmentNumber
-						</td>
-						<td>
-							@Model.ShipmentAuditItems[i].AuditType
-						</td>
-						<td>
-							@DisplayDate(@Model.ShipmentAuditItems[i].DateAdded)
-						</td>
-						<td>
-							@DisplayTime(@Model.ShipmentAuditItems[i].DateAdded)
-						</td>
-						<td>
-							@Model.ShipmentAuditItems[i].UserName
-						</td>
-					</tr>
-				}
+			@foreach (var auditRecord in Model.ShipmentAuditItems)
+			{
+			    <tr>
+			        <td>
+			            @auditRecord.ShipmentNumber
+			        </td>
+			        <td>
+			            @EnumHelper.GetDisplayName(auditRecord.AuditType)
+			        </td>
+			        <td>
+			            @DisplayDate(auditRecord.DateAdded)
+			        </td>
+			        <td>
+			            @DisplayTime(auditRecord.DateAdded)
+			        </td>
+			        <td>
+			            @auditRecord.UserName
+			        </td>
+			    </tr>
+			}
 			</tbody>
 		</table>
 	</div>

--- a/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
+++ b/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
@@ -1,5 +1,7 @@
 ﻿@using EA.Iws.Web.Infrastructure.Paging
+@using EA.Iws.Web.ViewModels
 @using EnumHelper = EA.Prsd.Core.Helpers.EnumHelper
+
 @model EA.Iws.Web.ViewModels.Shared.ShipmentAuditTrailViewModel
 @helper DisplayDate(DateTimeOffset date)
 {
@@ -71,5 +73,19 @@ else
 }
 @if (Model.ShipmentAuditItems.Count > 0)
 {
-	@Html.Pager(Model.PageSize, Model.PageNumber, Model.NumberOfShipmentAudits)
+    @Html.Pager(Model.PageSize, Model.PageNumber, Model.NumberOfShipmentAudits).Options(o =>
+    {
+        var selectedFilter = (ShipmentAuditFilterType?)ViewData["Filter"];
+        var number = (int?)ViewData["ShipmentNumber"];
+
+        if (selectedFilter.HasValue)
+        {
+            o.AddRouteValue("filter", (int)selectedFilter.Value);
+        }
+        if (number.HasValue)
+        {
+            o.AddRouteValue("number", (int)number.Value);
+        }
+    })
 }
+

--- a/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
+++ b/src/EA.Iws.Web/Views/Shared/_ShipmentAudit.cshtml
@@ -64,7 +64,7 @@ else
 {
 
 	<div class="margin-bottom-30 margin-top-30 ">
-		<h3 style="text-align:center; font-size:36px">No updates available</h3>
+		<h3 style="text-align:center; font-size:36px">No changes available</h3>
 	</div>
 
 }


### PR DESCRIPTION
PBIs
- 69250
- 69252
- 69261

Add searching/filtering for shipment number. Dropdown list presented to the user to switch between 'View all' and filter by shipment number.

Applies both to Import and Export notifications.

Additional changes:
- use enum display name for audit type and updated the no prenotification received type.
- add `DELETE` statements for shipment audit data when deleting Notifications (under Account services on the left hand menu).
