### PR TITLE
Active load count

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/NotificationMovementsSummaryRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/NotificationMovementsSummaryRepository.cs
@@ -65,7 +65,7 @@
                         || m.Status == MovementStatus.Received
                         || m.Status == MovementStatus.New
                         || m.Status == MovementStatus.Captured) 
-                    && m.Date < SystemTime.UtcNow)
+                    && m.Date <= SystemTime.UtcNow)
                 .CountAsync();
 
             var financialGuaranteeCollection =

--- a/src/EA.Iws.Database/scripts/Everytime/02-Views/0025-Reports-BlanketBonds.sql
+++ b/src/EA.Iws.Database/scripts/Everytime/02-Views/0025-Reports-BlanketBonds.sql
@@ -31,7 +31,7 @@ FROM
 		FG.[ActiveLoadsPermitted],
 		(SELECT COUNT(Id) FROM [Notification].[Movement] M
 			WHERE M.[NotificationId] = N.Id 
-			AND M.[Status] IN (2, 3)
+			AND M.[Status] IN (1, 2, 3, 7)
 			AND M.[Date] <= GETDATE()) AS [CurrentActiveLoads],
 		REPLACE(N.[NotificationNumber], ' ', '') AS [NotificationNumber],
 		E.[Name] AS [ExporterName],


### PR DESCRIPTION
PBIs:
- 69788
- 69847
- 69848
- 69849

The `NotificationMovementsSummaryRepository` is used across via internal and external screen and it is re-used as a partial view to display the small summary table.

NOTE - I found that the Financial Guarantees Report also counts active load so have updated that now. Will need to get confirmation with Gill/Mike first.

- UPDATE : confirmed to update the report too.