### PR TITLE
Movement factories date comparison

### DIFF
--- a/src/EA.Iws.Domain/ImportMovement/ImportMovementFactory.cs
+++ b/src/EA.Iws.Domain/ImportMovement/ImportMovementFactory.cs
@@ -11,6 +11,8 @@
     [AutoRegister]
     public class ImportMovementFactory : IImportMovementFactory
     {
+        private const int CalendarDaysLimit = 60;
+
         private readonly IImportMovementNumberValidator numberValidator;
         private readonly IImportNotificationAssessmentRepository assessmentRepository;
 
@@ -47,9 +49,12 @@
                 {
                     throw new InvalidOperationException("The actual date of shipment cannot be before the prenotification date.");
                 }
-                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(60))
+                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(CalendarDaysLimit))
                 {
-                    throw new InvalidOperationException("The actual date of shipment should not be more than 30 calendar days after the prenotification date.");
+                    throw new InvalidOperationException(
+                        string.Format(
+                            "The actual date of shipment should not be more than {0} calendar days after the prenotification date.",
+                            CalendarDaysLimit));
                 }
             }
 

--- a/src/EA.Iws.Domain/ImportMovement/ImportMovementFactory.cs
+++ b/src/EA.Iws.Domain/ImportMovement/ImportMovementFactory.cs
@@ -39,15 +39,15 @@
 
             if (prenotificationDate.HasValue)
             {
-                if (prenotificationDate > SystemTime.UtcNow.Date)
+                if (prenotificationDate.Value.Date > SystemTime.UtcNow.Date)
                 {
                     throw new InvalidOperationException("The prenotification date cannot be in the future.");
                 }
-                if (actualShipmentDate < prenotificationDate)
+                if (actualShipmentDate.Date < prenotificationDate.Value.Date)
                 {
                     throw new InvalidOperationException("The actual date of shipment cannot be before the prenotification date.");
                 }
-                if (actualShipmentDate > prenotificationDate.Value.AddDays(60))
+                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(60))
                 {
                     throw new InvalidOperationException("The actual date of shipment should not be more than 30 calendar days after the prenotification date.");
                 }

--- a/src/EA.Iws.Domain/Movement/CapturedMovementFactory.cs
+++ b/src/EA.Iws.Domain/Movement/CapturedMovementFactory.cs
@@ -46,15 +46,15 @@
 
             if (prenotificationDate.HasValue)
             {
-                if (prenotificationDate > SystemTime.UtcNow.Date)
+                if (prenotificationDate.Value.Date > SystemTime.UtcNow.Date)
                 {
                     throw new InvalidOperationException("The prenotification date cannot be in the future.");
                 }
-                if (actualShipmentDate < prenotificationDate)
+                if (actualShipmentDate.Date < prenotificationDate.Value.Date)
                 {
                     throw new InvalidOperationException("The actual date of shipment cannot be before the prenotification date.");
                 }
-                if (actualShipmentDate > prenotificationDate.Value.AddDays(60))
+                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(60))
                 {
                     throw new InvalidOperationException("The actual date of shipment should not be more than 30 calendar days after the prenotification date.");
                 }

--- a/src/EA.Iws.Domain/Movement/CapturedMovementFactory.cs
+++ b/src/EA.Iws.Domain/Movement/CapturedMovementFactory.cs
@@ -11,10 +11,12 @@
     [AutoRegister]
     public class CapturedMovementFactory : ICapturedMovementFactory
     {
+        private const int CalendarDaysLimit = 60;
+
         private readonly IMovementNumberValidator movementNumberValidator;
         private readonly INotificationAssessmentRepository assessmentRepository;
         private readonly IUserContext userContext;
-
+        
         public CapturedMovementFactory(IMovementNumberValidator movementNumberValidator, INotificationAssessmentRepository assessmentRepository,
             IUserContext userContext)
         {
@@ -54,9 +56,12 @@
                 {
                     throw new InvalidOperationException("The actual date of shipment cannot be before the prenotification date.");
                 }
-                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(60))
+                if (actualShipmentDate.Date > prenotificationDate.Value.Date.AddDays(CalendarDaysLimit))
                 {
-                    throw new InvalidOperationException("The actual date of shipment should not be more than 30 calendar days after the prenotification date.");
+                    throw new InvalidOperationException(
+                        string.Format(
+                            "The actual date of shipment should not be more than {0} calendar days after the prenotification date.",
+                            CalendarDaysLimit));
                 }
             }
 


### PR DESCRIPTION
I found this in PBI 69583. for Export notifications.

At the moment, for this PBI, we are using the existing Movement Factory to create the newly added shipments. This has validations around the date. Updated this to compare the date part only to deal with same day dates for Prenotification and Actual Date of shipment.

Also applied to the similar factory for Import Notifications.

**FURTHER ACTION** - have messaged Gill/Mike to confirm if we want to follow the same rules or not. Then potentially we would need to apply more validation rule around the Add New Shipment screen.