### PR TITLE
Update structure of view on the cancel home page.

### DIFF
--- a/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/Cancel/Index.cshtml
+++ b/src/EA.Iws.Web/Areas/AdminExportNotificationMovements/Views/Cancel/Index.cshtml
@@ -18,7 +18,7 @@
     <div class="form-group">
         <h2 class="heading-medium">@Resources.IndexSubHeader</h2>
 
-        @if (Model.SubmittedMovements.Count == 0 && Model.AddedMovements.Count == 0)
+        @if (Model.SubmittedMovements.Count == 0)
         {
             <p>@Resources.IndexNoPrenotifications</p>
         }
@@ -44,8 +44,8 @@
                     </thead>
                     <tbody>
                         @for (var i = 0; i < Model.SubmittedMovements.Count; i++)
-                    {
-                        var idForThisCheckBox = Html.NameFor(m => m.SubmittedMovements[i].IsSelected);
+                        {
+                            var idForThisCheckBox = Html.NameFor(m => m.SubmittedMovements[i].IsSelected);
 
                             <tr>
                                 <td>
@@ -60,7 +60,7 @@
                                     else
                                     {
                                         @:- -
-                                }
+                                    }
                                 </td>
                                 <td>
                                     @Html.Gds().DisplayShortDateFor(m => m.SubmittedMovements[i].ShipmentDate)
@@ -77,52 +77,56 @@
                     </tbody>
                 </table>
             </div>
+        }
 
-            if (Model.AddedMovements.Any())
-            {
-                <div class="form-group @Html.Gds().FormGroupClass(m => m.AddedMovements)">
-                    <h2 class="heading-medium">@Resources.AddSubHeader</h2>
-                    <table id="AddedMovements" title="@Resources.AddSubHeader">
-                        <thead>
+        @if (Model.AddedMovements.Any())
+        {
+            <div class="form-group @Html.Gds().FormGroupClass(m => m.AddedMovements)">
+                <h2 class="heading-medium">@Resources.AddSubHeader</h2>
+                <table id="AddedMovements" title="@Resources.AddSubHeader">
+                    <thead>
+                        <tr>
+                            <th>
+                                @Resources.ShipmentNumber
+                            </th>
+                            <th>
+                                @Resources.ActualDateOfShipment
+                            </th>
+                            <th>
+                                <label>@Constants.ActionText</label>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (var i = 0; i < Model.AddedMovements.Count(); i++)
+                    {
                             <tr>
-                                <th>
-                                    @Resources.ShipmentNumber
-                                </th>
-                                <th>
-                                    @Resources.ActualDateOfShipment
-                                </th>
-                                <th>
-                                    <label>@Constants.ActionText</label>
-                                </th>
+                                <td>
+                                    @Html.DisplayFor(m => m.AddedMovements[i].Number)
+                                </td>
+                                <td>
+                                    @Html.Gds().DisplayShortDateFor(m => m.AddedMovements[i].ShipmentDate)
+                                </td>
+                                <td>
+                                    <button class="link-submit" type="submit" name="command" value="@Model.AddedMovements[i].Number">@Constants.RemoveText</button>
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @for (var i = 0; i < Model.AddedMovements.Count(); i++)
-                        {
-                                <tr>
-                                    <td>
-                                        @Html.DisplayFor(m => m.AddedMovements[i].Number)
-                                    </td>
-                                    <td>
-                                        @Html.Gds().DisplayShortDateFor(m => m.AddedMovements[i].ShipmentDate)
-                                    </td>
-                                    <td>
-                                        <button class="link-submit" type="submit" name="command" value="@Model.AddedMovements[i].Number">@Constants.RemoveText</button>
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
-            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @if (Model.SubmittedMovements.Any() || Model.AddedMovements.Any())
+        {
             <div class="form-group">
                 <button class="button" type="submit">@Constants.ContinueOnlyButtonText</button>
             </div>
-
-            <div class="form-group">
-                <button class="link-submit" type="submit" name="command" value="add">@Resources.GoToAddNewShipments</button>
-            </div>
         }
+
+        <div class="form-group">
+            <button class="link-submit" type="submit" name="command" value="add">@Resources.GoToAddNewShipments</button>
+        </div>
     </div>
 }
 


### PR DESCRIPTION
Task 70839

Restructuring Index view (Cancel  home screen) to make sure the 2nd additional table and the add new shipments links appear even if there are no existing shipments to cancel.

Structure:

- Form
  - Existing shipments
  - New shipments
  - Display button if there any existing or new shipments
  - Always display the "I can't find the shipments I want to cancel" link