### PR TITLE
New shipments to be pending then cancelled

### DIFF
--- a/src/EA.Iws.RequestHandlers.Tests.Unit/Movement/CancelMovementsHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/Movement/CancelMovementsHandlerTests.cs
@@ -127,7 +127,7 @@
                                 m =>
                                     m.NotificationId == notificationId &&
                                     addedMovements.Exists(x => x.Number == m.ShipmentNumber) &&
-                                    m.Type == (int)MovementAuditType.Prenotified)))
+                                    m.Type == (int)MovementAuditType.NoPrenotificationReceived)))
                 .MustHaveHappened(Repeated.Exactly.Times(addedMovements.Count));
         }
 

--- a/src/EA.Iws.RequestHandlers/Movement/CancelMovementsHandler.cs
+++ b/src/EA.Iws.RequestHandlers/Movement/CancelMovementsHandler.cs
@@ -71,9 +71,6 @@
                 var movement = await capturedMovementFactory.Create(message.NotificationId, addedMovement.Number,
                     null, addedMovement.ShipmentDate, true);
 
-                movement.HasNoPrenotification = false;
-                movement.SubmitInternally(SystemTime.Now.Date);
-
                 repository.Add(movement);
 
                 await context.SaveChangesAsync();
@@ -84,7 +81,7 @@
             foreach (var movement in result)
             {
                 await movementAuditRepository.Add(new MovementAudit(movement.NotificationId, movement.Number,
-                    userContext.UserId.ToString(), (int)MovementAuditType.Prenotified, SystemTime.Now));
+                    userContext.UserId.ToString(), (int)MovementAuditType.NoPrenotificationReceived, SystemTime.Now));
             }
 
             await context.SaveChangesAsync();


### PR DESCRIPTION
PBIs:

- 69365
- 69583
- 69508
- 69585 (no work required but still considered as part of this change - testing wise)

Newly added shipments are now saved as Pending/Captured first rather than Prenotified and then marked as Cancel.

Reflected the same thing for the Audit Trail of the shipment.

COMPLIANCE REPORT - no change required. For Exports, it is looking at the HasNoPrenotification column in the Movement table.
For Imports - it just looks whether PrenotificationDate column is null.