### PR TITLE
Fixed delete notifcation issue.

### DIFF
--- a/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationRepository.cs
+++ b/src/EA.Iws.DataAccess/Repositories/Imports/ImportNotificationRepository.cs
@@ -54,8 +54,8 @@
 
         public async Task<Guid?> GetIdOrDefault(string number)
         {
-            return await context.ImportNotifications
-                .Where(n => n.NotificationNumber.Replace(" ", string.Empty) == number.Replace(" ", string.Empty))
+            return await context.ImportNotifications                
+                .Where(n => n.NotificationNumber.Trim() == number.Trim())
                 .Select(n => (Guid?)n.Id)
                 .SingleOrDefaultAsync();
         }

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -74,6 +74,7 @@
     <Content Include="scripts\TestData\20190123-175000-create-submitted-notification-2502.sql" />
     <Content Include="scripts\TestData\20191206-173100-create-export-notification-external-user-2506-EA.sql" />
     <Content Include="scripts\TestData\20191206-134000-create-export-notification-internal-user-2505-EA.sql" />
+    <Content Include="scripts\TestData\20210216-101500-add-multiple-duplicate-import-notification-consented.sql" />
     <Content Include="scripts\Update\0003-Migration\Sprint1\20170118-153400-drop-countryid.sql" />
     <Content Include="scripts\Update\0003-Migration\Sprint1\20170118-160400-add-indexes.sql" />
     <Content Include="scripts\Update\0003-Migration\Sprint1\20170119-114000-add-indexes.sql" />

--- a/src/EA.Iws.Database/scripts/TestData/20210216-101500-add-multiple-duplicate-import-notification-consented.sql
+++ b/src/EA.Iws.Database/scripts/TestData/20210216-101500-add-multiple-duplicate-import-notification-consented.sql
@@ -1,0 +1,436 @@
+﻿DECLARE @notificationNumberInc INT;
+SET @notificationNumberInc = 100;
+
+DECLARE @notificationNumberSeed NVARCHAR(11);
+SET @notificationNumberSeed = 'GB9999000'
+
+DECLARE @UserId UNIQUEIDENTIFIER;
+SELECT @UserId = id FROM [Identity].[aspnetusers] WHERE [email] = 'superuser@environment-agency.gov.uk'
+
+WHILE @notificationNumberInc < 103
+BEGIN
+	DECLARE @notificationNumber NVARCHAR(14)
+	SET @notificationNumber = @notificationNumberSeed + CAST(@notificationNumberInc AS VARCHAR(3))
+	SET @notificationNumberInc = @notificationNumberInc + 1;
+
+
+	--Add notification
+
+			DECLARE @ImportNotificationId UNIQUEIDENTIFIER = NEWID();
+
+			INSERT INTO [ImportNotification].[Notification]
+					   ([Id]
+					   ,[NotificationNumber]
+					   ,[NotificationType]
+					   ,[CompetentAuthority])
+				 VALUES
+					   (@ImportNotificationId,
+					   @notificationNumber,
+					   2,
+					   1) 
+
+			INSERT INTO [ImportNotification].[InterimStatus]
+					   ([Id]
+					   ,[IsInterim]
+					   ,[ImportNotificationId])
+				 VALUES
+					   (NEWID(),
+					   1,
+					   @ImportNotificationId)
+
+			DECLARE @FacilityCollectionId UNIQUEIDENTIFIER = NEWID();
+
+			INSERT INTO [ImportNotification].[FacilityCollection]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[AllFacilitiesPreconsented])
+				 VALUES
+					   (@FacilityCollectionId,
+					   @ImportNotificationId,
+					   1)
+
+			DECLARE @UKCountryId UNIQUEIDENTIFIER;
+			SELECT @UKCountryId = id
+			FROM   [Lookup].[country]
+			WHERE  [name] = 'United Kingdom';
+
+			INSERT INTO [ImportNotification].[Facility]
+					   ([Id]
+					   ,[FacilityCollectionId]
+					   ,[Name]
+					   ,[Type]
+					   ,[RegistrationNumber]
+					   ,[Address1]
+					   ,[Address2]
+					   ,[TownOrCity]
+					   ,[PostalCode]
+					   ,[CountryId]
+					   ,[ContactName]
+					   ,[Telephone]
+					   ,[Email]
+					   ,[IsActualSiteOfTreatment])
+				 VALUES
+					   (NEWID(),
+					   @FacilityCollectionId,
+					   N'Waste Treatment Facility',
+					   1,
+					   N'45645684546',
+					   N'5 Bib House',
+					   N'The Road',
+					   N'Brent',
+					   N'HJ3 7JI',
+					   @UKCountryId,
+					   N'Bob',
+					   N'09876 674534',
+					   N'lkjlj@asfasf.faa',
+					   1)
+
+			INSERT INTO [ImportNotification].[Facility]
+					   ([Id]
+					   ,[FacilityCollectionId]
+					   ,[Name]
+					   ,[Type]
+					   ,[RegistrationNumber]
+					   ,[Address1]
+					   ,[Address2]
+					   ,[TownOrCity]
+					   ,[PostalCode]
+					   ,[CountryId]
+					   ,[ContactName]
+					   ,[Telephone]
+					   ,[Email]
+					   ,[IsActualSiteOfTreatment])
+				 VALUES
+					   (NEWID(),
+					   @FacilityCollectionId,
+					   N'Scrap Waste Reclamation',
+					   1,
+					   N'45645684546',
+					   N'5 Bib House',
+					   N'The Road',
+					   N'Brent',
+					   N'HJ3 7JI',
+					   @UKCountryId,
+					   N'Bob',
+					   N'09876 674534',
+					   N'lkjlj@asfasf.faa',
+					   0)
+
+			INSERT INTO [ImportNotification].[Importer]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[Name]
+					   ,[Type]
+					   ,[RegistrationNumber]
+					   ,[Address1]
+					   ,[Address2]
+					   ,[TownOrCity]
+					   ,[PostalCode]
+					   ,[CountryId]
+					   ,[ContactName]
+					   ,[Telephone]
+					   ,[Email])
+				 VALUES
+					   (NEWID(),
+					   @ImportNotificationId,
+					   N'ImportersRUS',
+					   2,
+					   N'1234',
+					   N'Importer House',
+					   NULL,
+					   N'Hull',
+					   N'B78 89UI',
+					   @UKCountryId,
+					   N'Fred',
+					   N'44-3336669999',
+					   N'test@importer.com')
+
+			DECLARE @GreeceCountryId UNIQUEIDENTIFIER;
+			SELECT @GreeceCountryId = id
+			FROM   [Lookup].[country]
+			WHERE  [name] = 'Greece';
+
+			INSERT INTO [ImportNotification].[Producer]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[Name]
+					   ,[Address1]
+					   ,[Address2]
+					   ,[TownOrCity]
+					   ,[PostalCode]
+					   ,[CountryId]
+					   ,[ContactName]
+					   ,[Telephone]
+					   ,[Email]
+					   ,[IsOnlyProducer])
+				 VALUES
+					   (NEWID(),
+					   @ImportNotificationId,
+					   N'Producing Is Us',
+					   N'Producer House',
+					   NULL,
+					   N'Athens',
+					   N'B78 89UI',
+					   @GreeceCountryId,
+					   N'Fred',
+					   N'44-3336669999',
+					   N'test@importer.com',
+					   1)
+
+			INSERT INTO [ImportNotification].[Exporter]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[Name]
+					   ,[Address1]
+					   ,[Address2]
+					   ,[TownOrCity]
+					   ,[PostalCode]
+					   ,[CountryId]
+					   ,[ContactName]
+					   ,[Telephone]
+					   ,[Email])
+				 VALUES
+					   (NEWID(),
+					   @ImportNotificationId,
+					   N'Exporting Is Us',
+					   N'Exporter House',
+					   NULL,
+					   N'Athens',
+					   N'B78 89UI',
+					   @GreeceCountryId,
+					   N'Jim',
+					   N'44-3336667777',
+					   N'test@exporter.com')
+
+			INSERT INTO [ImportNotification].[Shipment]
+					   ([Id]
+					   ,[NumberOfShipments]
+					   ,[Quantity]
+					   ,[Units]
+					   ,[FirstDate]
+					   ,[LastDate]
+					   ,[ImportNotificationId])
+				 VALUES
+					   (NEWID(),
+					   520,
+					   Cast(25000.0000 AS DECIMAL(18, 4)),
+					   3,
+					   Cast(N'2015-09-01' AS DATE),
+					   Cast(N'2016-08-27' AS DATE),
+					   @ImportNotificationId)
+
+
+			DECLARE @TransportRouteId UNIQUEIDENTIFIER = NEWID();
+			INSERT INTO [ImportNotification].[TransportRoute]
+			([Id], [ImportNotificationId])
+			VALUES (@TransportRouteId, 
+					@ImportNotificationId)
+
+			DECLARE @GermanyCountryId UNIQUEIDENTIFIER;
+			SELECT @GermanyCountryId = id
+			FROM   [Lookup].[country]
+			WHERE  [name] = 'Germany';
+
+			DECLARE @CAId UNIQUEIDENTIFIER;
+			SELECT @CAId = id
+			FROM   [Lookup].[competentauthority]
+			WHERE  [code] = 'DE018';
+
+			DECLARE @ExitId UNIQUEIDENTIFIER;
+			SELECT @ExitId = id
+			FROM   [Notification].[entryorexitpoint]
+			WHERE  [name] = 'Aachen';
+
+			INSERT INTO [ImportNotification].[StateOfExport]
+					   ([Id]
+					   ,[TransportRouteId]
+					   ,[CountryId]
+					   ,[CompetentAuthorityId]
+					   ,[ExitPointId])
+				 VALUES
+					   (NEWID(),
+					   @TransportRouteId,
+					   @GermanyCountryId,
+					   @CAId,
+					   @ExitId)
+
+			SELECT @CAId = id
+			FROM   [Lookup].[competentauthority]
+			WHERE  [code] = 'GB01';
+
+			DECLARE @EntryId UNIQUEIDENTIFIER;
+			SELECT @EntryId = id
+			FROM   [Notification].[entryorexitpoint]
+			WHERE  [name] = 'Dover';
+
+			INSERT INTO [ImportNotification].[StateOfImport]
+					   ([Id]
+					   ,[TransportRouteId]
+					   ,[CompetentAuthorityId]
+					   ,[EntryPointId])
+				 VALUES
+					   (NEWID(),
+					   @TransportRouteId,
+					   @CAId,
+					   @EntryId)
+
+			DECLARE @CountryId UNIQUEIDENTIFIER;
+			SELECT @CountryId = id
+			FROM   [Lookup].[country]
+			WHERE  [name] = 'France';
+
+			SELECT @CAId = id
+			FROM   [Lookup].[competentauthority]
+			WHERE  [code] = 'F';
+
+			SELECT @EntryId = id
+			FROM   [Notification].[entryorexitpoint]
+			WHERE  [name] = 'Calais';
+
+			SELECT @ExitId = id
+			FROM   [Notification].[entryorexitpoint]
+			WHERE  [name] = 'Lille';
+
+			INSERT INTO [ImportNotification].[TransitState]
+					   ([Id]
+					   ,[TransportRouteId]
+					   ,[CountryId]
+					   ,[CompetentAuthorityId]
+					   ,[EntryPointId]
+					   ,[ExitPointId]
+					   ,[OrdinalPosition])
+				 VALUES
+					   (NEWID(),
+					   @TransportRouteId,
+					   @CountryId,
+					   @CAId,
+					   @EntryId,
+					   @ExitId,
+					   1)
+
+			DECLARE @WasteOperationId UNIQUEIDENTIFIER = NEWID();
+
+			INSERT INTO [ImportNotification].[WasteOperation]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[TechnologyEmployed])
+				 VALUES
+					   (@WasteOperationId,
+					   @ImportNotificationId,
+					   N'Mulching')
+
+			INSERT INTO [ImportNotification].[OperationCodes]
+					   ([Id]
+					   ,[WasteOperationId]
+					   ,[OperationCode])
+				 VALUES
+					   (NEWID(),
+					   @WasteOperationId,
+					   10)
+
+			DECLARE @WasteTypeId UNIQUEIDENTIFIER = NEWID();
+
+			INSERT INTO [ImportNotification].[WasteType]
+					   ([Id]
+					   ,[ImportNotificationId]
+					   ,[Name]
+					   ,[BaselOecdCodeNotListed]
+					   ,[YCodeNotApplicable]
+					   ,[HCodeNotApplicable]
+					   ,[UnClassNotApplicable]
+					   ,[ChemicalCompositionType])
+				 VALUES
+					   (@WasteTypeId,
+					   @ImportNotificationId,
+					   N'Rubish',
+					   1,
+					   1,
+					   1,
+					   1,
+					   1)
+
+			INSERT INTO [ImportNotification].[WasteCode]
+					   ([Id]
+					   ,[WasteTypeId]
+					   ,[WasteCodeId])
+				 VALUES
+					   (NEWID(),
+					   @WasteTypeId,
+					   (SELECT TOP 1 id FROM [Lookup].[WasteCode] WHERE [code] = '01 01 01' AND [CodeType] = 3 ))
+
+
+			DECLARE @NotificationAssessmentId UNIQUEIDENTIFIER = NEWID();
+
+			INSERT INTO [ImportNotification].[NotificationAssessment]
+					   ([Id]
+					   ,[NotificationApplicationId]
+					   ,[Status])
+				 VALUES
+					   (@NotificationAssessmentId,
+					   @ImportNotificationId,
+					   9)
+
+
+			INSERT INTO [ImportNotification].[NotificationDates]
+					   ([Id]
+					   ,[NotificationAssessmentId]
+					   ,[NotificationReceivedDate]
+					   ,[PaymentReceivedDate]
+					   ,[AssessmentStartedDate]
+					   ,[NameOfOfficer]
+					   ,[NotificationCompletedDate]
+					   ,[AcknowledgedDate]
+					   ,[ConsentedDate])
+				 VALUES
+					   (NEWID(),
+					   @NotificationAssessmentId,
+					   Cast(N'2016-01-01' AS DATE),
+					   Cast(N'2016-01-02' AS DATE),
+					   Cast(N'2016-01-03' AS DATE),
+					   N'Santa',
+					   Cast(N'2016-01-04' AS DATE),
+					   Cast(N'2016-01-05' AS DATE),
+					   Cast(N'2016-01-06' AS DATE))
+
+
+			INSERT INTO [ImportNotification].[Consent]
+					   ([Id]
+					   ,[From]
+					   ,[To]
+					   ,[Conditions]
+					   ,[UserId]
+					   ,[NotificationId])
+				 VALUES
+					   (NEWID(),
+					   Cast(N'2016-01-01' AS DATE),
+					   Cast(N'2016-12-31' AS DATE),
+					   N'Be nice',
+					   @UserId,
+					   @ImportNotificationId)
+
+	--End Add notification
+
+	--Add movements
+
+			DECLARE @shipmentNumber INT;
+			SET @shipmentNumber = 1;
+
+			WHILE @shipmentNumber < 5
+			BEGIN
+				DECLARE @movementId uniqueidentifier = NEWID()
+				INSERT INTO [ImportNotification].[Movement]([Id], [Number], [NotificationId], [ActualShipmentDate], [IsCancelled])
+					   VALUES(@movementId, @shipmentNumber, @ImportNotificationId, Cast(N'2016-11-01' AS DATE), 'false');
+
+				INSERT INTO [ImportNotification].[MovementReceipt]([Id], [MovementId], [Date], [Quantity], [Unit])
+					   VALUES (NEWID(), @movementId, Cast(N'2016-11-10' AS DATE), 1, 3)
+				
+				SET @shipmentNumber = @shipmentNumber + 1;
+			END;
+
+	--End Add movements
+
+	-- Add comment
+	INSERT INTO [ImportNotification].[Comments] ([Id], [NotificationId], [UserId], [ShipmentNumber], [Comment], [DateAdded])
+	VALUES (NEWID(), @ImportNotificationId, @UserId, @notificationNumberInc, 'Some really interesting comment', GETDATE());
+
+END;

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -114,6 +114,7 @@
     <Compile Include="ImportMovement\GetImportMovementAuditByNotificationIdHandlerTests.cs" />
     <Compile Include="ImportNotification\AddImportNotificationCommentsHandlerTests.cs" />
     <Compile Include="ImportNotification\DeleteImportNotificationCommentHandlerTest.cs" />
+    <Compile Include="ImportNotification\DeleteImportNotificationHandlerTests.cs" />
     <Compile Include="ImportNotification\Draft\TransitStateCollectionTests.cs" />
     <Compile Include="ImportNotification\GetImportNotificationCommentsHandlerTests.cs" />
     <Compile Include="ImportNotification\GetImportNotificationCommentsUsersHandlerTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/ImportNotification/DeleteImportNotificationHandlerTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/ImportNotification/DeleteImportNotificationHandlerTests.cs
@@ -1,0 +1,47 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.ImportNotification
+{
+    using System;
+    using System.Threading.Tasks;
+    using EA.Iws.Domain.ImportNotification;
+    using EA.Iws.RequestHandlers.ImportNotification;
+    using EA.Iws.RequestHandlers.ImportNotificationAssessment;
+    using EA.Iws.Requests.ImportNotification;
+    using EA.Iws.Requests.ImportNotificationAssessment;
+    using FakeItEasy;
+    using Xunit;
+
+    public class DeleteImportNotificationHandlerTests
+    {
+        private readonly IImportNotificationRepository repo;
+        private readonly DeleteImportNotificationHandler handler;
+        private readonly GetImportNotificationNumberByIdHandler notificationHandler;
+        private readonly DeleteImportNotification message;
+        private readonly GetImportNotificationNumberById importNotificationId;
+
+        public DeleteImportNotificationHandlerTests()
+        {
+            this.repo = A.Fake<IImportNotificationRepository>();
+            this.message = A.Fake<DeleteImportNotification>();
+            this.handler = new DeleteImportNotificationHandler(this.repo);
+            this.notificationHandler = new GetImportNotificationNumberByIdHandler(this.repo);
+            this.importNotificationId = A.Fake<GetImportNotificationNumberById>();
+        }
+
+        [Fact]
+        public async Task DeleteImportNotification_ReturnsTrue()
+        {
+            A.CallTo(() => repo.Delete(A<Guid>.Ignored)).Returns(true);
+            var result = await handler.HandleAsync(this.message);
+            Assert.True(result);
+            A.CallTo(() => this.repo.Delete(A<Guid>.Ignored)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task DeleteImportNotification_NotExist_ReturnsEmpty()
+        {
+            A.CallTo(() => repo.Delete(this.message.NotificationId)).Returns(true);
+            var result = await notificationHandler.HandleAsync(this.importNotificationId);
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
The dev work to fix this issue has been completed by Sreedhar Bangarugari <Sreedhar.Bangarugari@civica.co.uk>. The email refers below.

I have investigated the support ticket (R:374753 – IWS Project) and identified that it’s required a code fix to resolve this issue. 

While selecting the Notification record, it should return a single record as per the method (ImportNotificationRepository - GetIdOrDefault(string number)). But the code is treating 2 different notification names (ex: TEST 0001 and TEST0001) as the same. But as per the database, both of them are different records and it should return to the right record as per the user input.

In the code ImportNotificationRepository - GetIdOrDefault(string number) method, line number 58 the notification number space characters are replacing with string.Empty therefore it’s causing an issue.

I have fixed and pushed changes into the local branch (374753-delete-notification). Please do let me know if we need to create a change request documentation.

As per my knowledge, the change doesn’t have any other impact and I will continue my investigation and let you know if there are any other findings.

Note: While creating Import notification records, the code is removing/trimming the starting and ending space characters only and not the spaces between the text.

Many Thanks,
Sreedhar
