### PR TITLE
Set waste category type as empty when it is null to avoid generating …

### DIFF
--- a/src/EA.Iws.DocumentGeneration/ViewModels/WasteCompositionViewModel.cs
+++ b/src/EA.Iws.DocumentGeneration/ViewModels/WasteCompositionViewModel.cs
@@ -35,6 +35,10 @@
             {
                 WasteCategoryType = EnumHelper.GetDisplayName(wasteType.WasteCategoryType.Value);
             }
+            else
+            {
+                WasteCategoryType = string.Empty;
+            }
 
             SetMergeDescriptionText();
         }


### PR DESCRIPTION
…word document.