### PR TITLE
Add LastLoginDate tracking to user entities and DB

### DIFF
--- a/src/EA.Iws.Api/IdSrv/UserService.cs
+++ b/src/EA.Iws.Api/IdSrv/UserService.cs
@@ -2,12 +2,26 @@
 {
     using DataAccess.Identity;
     using Identity;
+    using IdentityServer3.Core.Models;
+    using System;
+    using System.Threading.Tasks;
 
     public class UserService : AspNetIdentityUserService<ApplicationUser, string>
     {
+        private readonly ApplicationUserManager userManager;
+
         public UserService(ApplicationUserManager userMgr)
             : base(userMgr)
         {
+            userManager = userMgr;
+        }
+        protected override async Task<AuthenticateResult> PostAuthenticateLocalAsync(ApplicationUser user, SignInMessage message)
+        {
+            // Update the last login date on successful authentication
+            user.LastLoginDate = DateTime.UtcNow;
+            await userManager.UpdateAsync(user);
+
+            return await base.PostAuthenticateLocalAsync(user, message);
         }
     }
 }

--- a/src/EA.Iws.Core/Admin/InternalUserData.cs
+++ b/src/EA.Iws.Core/Admin/InternalUserData.cs
@@ -30,5 +30,7 @@
         }
 
         public UserRole Role { get; set; }
+        public DateTime? LastLoginDate { get; set; }
+
     }
 }

--- a/src/EA.Iws.DataAccess/Identity/ApplicationUser.cs
+++ b/src/EA.Iws.DataAccess/Identity/ApplicationUser.cs
@@ -9,5 +9,6 @@
         public string FirstName { get; set; }
         public string Surname { get; set; }
         public Guid? OrganisationId { get; private set; }
+        public DateTime? LastLoginDate { get; set; }
     }
 }

--- a/src/EA.Iws.DataAccess/Mappings/Exports/UserMapping.cs
+++ b/src/EA.Iws.DataAccess/Mappings/Exports/UserMapping.cs
@@ -13,6 +13,7 @@
             Property(x => x.Surname).IsRequired().HasMaxLength(256);
             Property(x => x.Email).IsRequired().HasMaxLength(256);
             Property(x => x.PhoneNumber).IsOptional();
+            Property(x => x.LastLoginDate).IsOptional();
         }
     }
 }

--- a/src/EA.Iws.Database/EA.Iws.Database.csproj
+++ b/src/EA.Iws.Database/EA.Iws.Database.csproj
@@ -191,6 +191,7 @@
     <Content Include="scripts\Update\0007-Support\20251029-1544-SEPA-2024-25-price-matrices-update.sql" />
     <Content Include="scripts\Update\0007-Support\20251125-1610-Spanish-competent-authority-changes.sql" />
     <Content Include="scripts\Update\0007-Support\20251212-1400-Alter-Country-Macedonia.sql" />
+    <Content Include="scripts\Update\0007-Support\20260304-0900-Alter-Identity-AspNetUsers-add-LastLoginDate.sql" />
     <Content Include="scripts\Update\placeholder.txt" />
     <Content Include="unindexed-foreign-keys.sql" />
     <Content Include="scripts\Everytime\01-Functions\0004-Notification-GetPricingInfo.sql" />

--- a/src/EA.Iws.Database/scripts/Update/0007-Support/20260304-0900-Alter-Identity-AspNetUsers-add-LastLoginDate.sql
+++ b/src/EA.Iws.Database/scripts/Update/0007-Support/20260304-0900-Alter-Identity-AspNetUsers-add-LastLoginDate.sql
@@ -1,0 +1,3 @@
+-- This script adds a new column to the AspNetUsers table to store the last login date of the user.
+ALTER TABLE [Identity].[AspNetUsers] ADD [LastLoginDate] DATETIME2 NULL;
+GO

--- a/src/EA.Iws.Domain.Tests.Unit/UserTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/UserTests.cs
@@ -45,5 +45,71 @@
 
             Assert.Throws<ArgumentNullException>("organisation", linkToOrganisation);
         }
+
+        [Fact]
+        public void LastLoginDate_WhenNotSet_IsNull()
+        {
+            Assert.Null(anyUser.LastLoginDate);
+        }
+
+        [Fact]
+        public void LastLoginDate_WhenSet_ReturnsCorrectValue()
+        {
+            var expectedDate = new DateTime(2026, 3, 3, 10, 30, 0, DateTimeKind.Utc);
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                expectedDate);
+
+            Assert.Equal(expectedDate, user.LastLoginDate);
+        }
+
+        [Fact]
+        public void LastLoginDate_WhenSetToMinValue_ReturnsMinValue()
+        {
+            var minDate = DateTime.MinValue;
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                minDate);
+
+            Assert.Equal(minDate, user.LastLoginDate);
+        }
+
+        [Fact]
+        public void LastLoginDate_WhenExplicitlySetToNull_IsNull()
+        {
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                null);
+
+            Assert.Null(user.LastLoginDate);
+        }
+
+        [Fact]
+        public void UserFactory_CreateWithLastLoginDate_SetsAllProperties()
+        {
+            var id = new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B");
+            var expectedDate = new DateTime(2026, 3, 3, 10, 30, 0, DateTimeKind.Utc);
+
+            var user = UserFactory.Create(id, "first", "last", "123", "email@address.com", expectedDate);
+
+            Assert.Equal(id.ToString(), user.Id);
+            Assert.Equal("first", user.FirstName);
+            Assert.Equal("last", user.Surname);
+            Assert.Equal("123", user.PhoneNumber);
+            Assert.Equal("email@address.com", user.Email);
+            Assert.Equal(expectedDate, user.LastLoginDate);
+        }
     }
 }

--- a/src/EA.Iws.Domain/User.cs
+++ b/src/EA.Iws.Domain/User.cs
@@ -38,6 +38,8 @@
 
         public string UserName { get; private set; }
 
+        public DateTime? LastLoginDate { get; private set; }
+
         public virtual Organisation Organisation { get; private set; }
 
         public void LinkToOrganisation(Organisation organisation)

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/EA.Iws.RequestHandlers.Tests.Unit.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Mappings\ContactMapTests.cs" />
     <Compile Include="Mappings\ExporterMapTests.cs" />
     <Compile Include="Mappings\BusinessTestBase.cs" />
+    <Compile Include="Mappings\InternalUserMapTests.cs" />
     <Compile Include="Mappings\WasteAdditionalInformationMapTests.cs" />
     <Compile Include="Mappings\WasteCodeMapTests.cs" />
     <Compile Include="MessageBanner\GetMessageBannerHandlerTests.cs" />

--- a/src/EA.Iws.RequestHandlers.Tests.Unit/Mappings/InternalUserMapTests.cs
+++ b/src/EA.Iws.RequestHandlers.Tests.Unit/Mappings/InternalUserMapTests.cs
@@ -1,0 +1,117 @@
+﻿namespace EA.Iws.RequestHandlers.Tests.Unit.Mappings
+{
+    using Core.Authorization;
+    using RequestHandlers.Mappings;
+    using System;
+    using System.Collections.Generic;
+    using System.Security.Claims;
+    using TestHelpers.Helpers;
+    using Xunit;
+
+    public class InternalUserMapTests
+    {
+        private readonly InternalUserMap mapper;
+
+        public InternalUserMapTests()
+        {
+            mapper = new InternalUserMap();
+        }
+
+        [Fact]
+        public void Map_WhenSourceIsNull_ReturnsNull()
+        {
+            var result = mapper.Map(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Map_WhenLastLoginDateIsSet_MapsLastLoginDate()
+        {
+            var expectedDate = new DateTime(2026, 3, 5, 10, 30, 0, DateTimeKind.Utc);
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                expectedDate);
+            var internalUser = InternalUserFactory.Create(
+                new Guid("5F09CFBF-9287-4DDD-9B73-6F9008A7E121"),
+                user);
+
+            var result = mapper.Map(internalUser);
+
+            Assert.Equal(expectedDate, result.LastLoginDate);
+        }
+
+        [Fact]
+        public void Map_WhenLastLoginDateIsNull_MapsNullLastLoginDate()
+        {
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com");
+            var internalUser = InternalUserFactory.Create(
+                new Guid("5F09CFBF-9287-4DDD-9B73-6F9008A7E121"),
+                user);
+
+            var result = mapper.Map(internalUser);
+
+            Assert.Null(result.LastLoginDate);
+        }
+
+        [Fact]
+        public void MapWithClaims_WhenLastLoginDateIsSet_MapsLastLoginDate()
+        {
+            var expectedDate = new DateTime(2026, 3, 5, 10, 30, 0, DateTimeKind.Utc);
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                expectedDate);
+            var internalUser = InternalUserFactory.Create(
+                new Guid("5F09CFBF-9287-4DDD-9B73-6F9008A7E121"),
+                user);
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Role, UserRole.Internal.ToString().ToLowerInvariant())
+            };
+
+            var result = mapper.Map(internalUser, claims);
+
+            Assert.Equal(expectedDate, result.LastLoginDate);
+        }
+
+        [Fact]
+        public void Map_MapsAllProperties()
+        {
+            var expectedDate = new DateTime(2026, 3, 5, 10, 30, 0, DateTimeKind.Utc);
+            var user = UserFactory.Create(
+                new Guid("FB282058-6C3C-4B4B-94B4-BDDA2889E89B"),
+                "first",
+                "last",
+                "123",
+                "email@address.com",
+                expectedDate);
+            var internalUser = InternalUserFactory.Create(
+                new Guid("5F09CFBF-9287-4DDD-9B73-6F9008A7E121"),
+                user);
+
+            var result = mapper.Map(internalUser);
+
+            Assert.Equal(internalUser.Id, result.Id);
+            Assert.Equal(internalUser.UserId, result.UserId);
+            Assert.Equal(user.Email, result.Email);
+            Assert.Equal(user.FirstName, result.FirstName);
+            Assert.Equal(user.Surname, result.Surname);
+            Assert.Equal(user.PhoneNumber, result.PhoneNumber);
+            Assert.Equal(expectedDate, result.LastLoginDate);
+            Assert.Equal(UserRole.Internal, result.Role);
+        }
+    }
+}

--- a/src/EA.Iws.RequestHandlers/Mappings/InternalUserMap.cs
+++ b/src/EA.Iws.RequestHandlers/Mappings/InternalUserMap.cs
@@ -28,7 +28,8 @@
                 Status = source.Status,
                 JobTitle = source.JobTitle,
                 PhoneNumber = source.User.PhoneNumber,
-                Role = UserRole.Internal
+                Role = UserRole.Internal,
+                LastLoginDate = source.User.LastLoginDate
             };
         }
 

--- a/src/EA.Iws.TestHelpers/Helpers/UserFactory.cs
+++ b/src/EA.Iws.TestHelpers/Helpers/UserFactory.cs
@@ -18,5 +18,13 @@
 
             return user;
         }
+
+        public static User Create(Guid id, string firstName, string lastName, string phoneNumber, string email, DateTime? lastLoginDate)
+        {
+            var user = Create(id, firstName, lastName, phoneNumber, email);
+            ObjectInstantiator<User>.SetProperty(u => u.LastLoginDate, lastLoginDate, user);
+
+            return user;
+        }
     }
 }

--- a/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/ChangeUserStatus.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/ChangeUserStatus.cshtml
@@ -12,6 +12,7 @@
             <th>@Resources.Name</th>
             <th>@Resources.Role</th>
             <th>@Resources.Status</th>
+            <th style="min-width: 150px;">Last login</th>
             <th>Action</th>
         </tr>
     </thead>
@@ -23,12 +24,13 @@
                 @Html.AntiForgeryToken()
                 @Html.Hidden("UserId", Model.Users[i].UserId)
 
-                <tr>
-                    <td class="font-xsmall" title="@Model.Users[i].Email">@Model.Users[i].FullName</td>
-                    <td class="font-xsmall">@Model.Users[i].Role</td>
-                    <td>@Html.DropDownList("Status", Model.GetUserStatusList(Model.Users[i].Status), new { id = string.Format("Status{0}", i), @class = "govuk-select" })</td>
-                    <td><button type="submit" style="width:auto; padding: 5px!important;margin-bottom: 0px!important" class="govuk-button">@Resources.Update</button></td>
-                </tr>
+        <tr>
+            <td class="font-xsmall" title="@Model.Users[i].Email">@Model.Users[i].FullName</td>
+            <td class="font-xsmall">@Model.Users[i].Role</td>
+            <td>@Html.DropDownList("Status", Model.GetUserStatusList(Model.Users[i].Status), new { id = string.Format("Status{0}", i), @class = "govuk-select" })</td>
+            <td class="font-xsmall">@(Model.Users[i].LastLoginDate.HasValue ? Model.Users[i].LastLoginDate.Value.ToString("dd MMM yyyy HH:mm") : "")</td>
+            <td><button type="submit" style="width:auto; padding: 5px!important;margin-bottom: 0px!important" class="govuk-button">@Resources.Update</button></td>
+        </tr>
             }
         }
     </tbody>

--- a/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/ChangeUserStatus.cshtml
+++ b/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/ChangeUserStatus.cshtml
@@ -12,7 +12,7 @@
             <th>@Resources.Name</th>
             <th>@Resources.Role</th>
             <th>@Resources.Status</th>
-            <th style="min-width: 150px;">Last login</th>
+            <th style="min-width: 150px;">@Resources.LastLogin</th>
             <th>Action</th>
         </tr>
     </thead>

--- a/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/UserAdministrationResources.Designer.cs
+++ b/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/UserAdministrationResources.Designer.cs
@@ -97,6 +97,15 @@ namespace EA.Iws.Web.Areas.Admin.Views.UserAdministration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Last login date.
+        /// </summary>
+        public static string LastLogin {
+            get {
+                return ResourceManager.GetString("LastLogin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string Name {

--- a/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/UserAdministrationResources.resx
+++ b/src/EA.Iws.Web/Areas/Admin/Views/UserAdministration/UserAdministrationResources.resx
@@ -129,6 +129,9 @@
   <data name="Email" xml:space="preserve">
     <value>Email</value>
   </data>
+  <data name="LastLogin" xml:space="preserve">
+    <value>Last login date</value>
+  </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>
   </data>


### PR DESCRIPTION
Introduce LastLoginDate property to ApplicationUser and User classes to record the user's last successful login. Update UserService to set and persist LastLoginDate on authentication. Add EF mapping and database migration for LastLoginDate column. Extend UserFactory and add unit tests for LastLoginDate behavior.

[Trello card](https://trello.com/c/Yn07CDrX/245-record-last-date-of-login-for-user-accounts)