### PR TITLE
Expand MovementStatus.New transitions for rejection

### DIFF
--- a/src/EA.Iws.Domain/Movement/Movement.cs
+++ b/src/EA.Iws.Domain/Movement/Movement.cs
@@ -163,7 +163,9 @@
 
             stateMachine.Configure(MovementStatus.New)
                 .Permit(Trigger.Submit, MovementStatus.Submitted)
-                .Permit(Trigger.ReceiveInternal, MovementStatus.Received);
+                .Permit(Trigger.ReceiveInternal, MovementStatus.Received)
+                .Permit(Trigger.PartialReject, MovementStatus.PartiallyRejected)
+                .Permit(Trigger.Reject, MovementStatus.Rejected);
 
             stateMachine.Configure(MovementStatus.Submitted)
                 .OnEntryFrom(submittedTrigger, OnSubmitted)


### PR DESCRIPTION
Added PartialReject and Reject triggers to allow transitions from MovementStatus.New to PartiallyRejected and Rejected states, respectively. This enhances the state machine's flexibility in handling movement rejections at the initial stage.