### PR TITLE
Refactor payment received logic to use TotalBillable

### DIFF
--- a/src/EA.Iws.Domain.Tests.Unit/ImportNotificationAssessment/Transactions/ImportPaymentTransactionTests.cs
+++ b/src/EA.Iws.Domain.Tests.Unit/ImportNotificationAssessment/Transactions/ImportPaymentTransactionTests.cs
@@ -7,7 +7,6 @@
     using Domain.ImportNotification;
     using Domain.ImportNotificationAssessment;
     using Domain.ImportNotificationAssessment.Transactions;
-    using Domain.NotificationAssessment;
     using FakeItEasy;
     using Xunit;
 
@@ -31,8 +30,11 @@
             A.CallTo(() => importNotificationAssessmentRepository.GetByNotification(notificationId))
                 .Returns(assessment);
 
-            A.CallTo(() => importNotificationTransactionCalculator.Balance(notificationId))
-                .Returns(1000);
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
+
+            A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
+                .Returns(new List<ImportNotificationTransaction>());
 
             transaction = new ImportPaymentTransaction(
                 importNotificationTransactionRepository,
@@ -51,22 +53,59 @@
         {
             var transactionDate = new DateTime(2018, 1, 1);
 
-            A.CallTo(() => importNotificationTransactionCalculator.Balance(notificationId))
-                .Returns(1000);
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
             A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
-                .Returns(new List<ImportNotificationTransaction>() { CreateNotificationTransaction(1000, transactionDate) });
+                .Returns(new List<ImportNotificationTransaction>());
 
             await transaction.Save(notificationId, transactionDate, 1000, PaymentMethod.Card, null, null);
 
-            Assert.Equal(assessment.Dates.PaymentReceivedDate, transactionDate);
+            Assert.Equal(transactionDate, assessment.Dates.PaymentReceivedDate);
         }
 
         [Fact]
         public async Task Save_PaymentNotFullyReceived_ReceivedDateNull()
         {
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
+
             await transaction.Save(notificationId, new DateTime(2018, 1, 1), 999, PaymentMethod.Card, null, null);
 
             Assert.Null(assessment.Dates.PaymentReceivedDate);
+        }
+
+        [Fact]
+        public async Task Save_PartialPaymentsThenFullPayment_SetsCorrectReceivedDate()
+        {
+            var firstPaymentDate = new DateTime(2018, 1, 1);
+            var secondPaymentDate = new DateTime(2018, 2, 1);
+
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
+            A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
+                .Returns(new List<ImportNotificationTransaction>
+                {
+                    CreateNotificationTransaction(600, firstPaymentDate)
+                });
+
+            await transaction.Save(notificationId, secondPaymentDate, 400, PaymentMethod.Card, null, null);
+
+            Assert.Equal(secondPaymentDate, assessment.Dates.PaymentReceivedDate);
+        }
+
+        [Fact]
+        public async Task Save_NonAwaitingPaymentStatus_SetsReceivedDateDirectly()
+        {
+            var transactionDate = new DateTime(2025, 7, 14);
+
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(6700m);
+            A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
+                .Returns(new List<ImportNotificationTransaction>());
+
+            await transaction.Save(notificationId, transactionDate, 6700, PaymentMethod.Card, null, null);
+
+            Assert.Equal(transactionDate, assessment.Dates.PaymentReceivedDate);
         }
 
         [Fact]
@@ -78,13 +117,13 @@
             A.CallTo(() => importNotificationTransactionRepository.GetById(transactionId))
                 .Returns(notificationTransaction);
 
-            // Set payment to fully received
-            A.CallTo(() => importNotificationTransactionCalculator.Balance(notificationId))
-                .Returns(0);
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
+            A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
+                .Returns(new List<ImportNotificationTransaction> { notificationTransaction });
 
             assessment.Dates.PaymentReceivedDate = new DateTime(2017, 2, 2);
 
-            // Delete payment, balance now £600
             await transaction.Delete(notificationId, transactionId);
 
             Assert.Null(assessment.Dates.PaymentReceivedDate);
@@ -96,24 +135,21 @@
             var expectedPaymentDate = new DateTime(2018, 2, 2);
             var transactionId = new Guid("F7DF1DD7-E356-47E2-8C9C-281C4A824F94");
             var transactionToDelete = CreateNotificationTransaction(100, new DateTime(2018, 4, 4));
-            var transactionRemaining = CreateNotificationTransaction(200, expectedPaymentDate);
+            var transactionRemaining = CreateNotificationTransaction(1000, expectedPaymentDate);
 
             A.CallTo(() => importNotificationTransactionRepository.GetById(transactionId))
                 .Returns(transactionToDelete);
 
-            // Set payment to overpaid
-            A.CallTo(() => importNotificationTransactionCalculator.Balance(notificationId))
-                .Returns(-200);
-
+            A.CallTo(() => importNotificationTransactionCalculator.TotalBillable(notificationId))
+                .Returns(1000m);
             A.CallTo(() => importNotificationTransactionRepository.GetTransactions(notificationId))
-                .Returns(new List<ImportNotificationTransaction>() { CreateNotificationTransaction(200, expectedPaymentDate) });
+                .Returns(new List<ImportNotificationTransaction> { transactionToDelete, transactionRemaining });
 
             assessment.Dates.PaymentReceivedDate = new DateTime(2017, 2, 2);
 
-            // Delete payment, balance now -£100
             await transaction.Delete(notificationId, transactionId);
 
-            Assert.Equal(assessment.Dates.PaymentReceivedDate, expectedPaymentDate);
+            Assert.Equal(expectedPaymentDate, assessment.Dates.PaymentReceivedDate);
         }
     }
 }

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/IImportNotificationTransactionCalculator.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/IImportNotificationTransactionCalculator.cs
@@ -7,6 +7,8 @@
     {
         Task<decimal> TotalPaid(Guid importNotificationId);
 
+        Task<decimal> TotalBillable(Guid importNotificationId);
+
         Task<bool> PaymentIsNowFullyReceived(Guid importNotificationId, decimal credit);
 
         Task<decimal> Balance(Guid importNotificationId);

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/ImportNotificationTransactionCalculator.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/ImportNotificationTransactionCalculator.cs
@@ -27,6 +27,11 @@
             return TotalCredits(transactions) - TotalDebits(transactions);
         }
 
+        public Task<decimal> TotalBillable(Guid importNotificationId)
+        {
+            return chargeCalculator.GetValue(importNotificationId);
+        }
+
         private static decimal TotalCredits(IEnumerable<ImportNotificationTransaction> transactions)
         {
             Guard.ArgumentNotNull(() => transactions, transactions);
@@ -83,6 +88,7 @@
                     }
                 }
             }
+
             return null;
         }
     }

--- a/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/ImportPaymentTransaction.cs
+++ b/src/EA.Iws.Domain/ImportNotificationAssessment/Transactions/ImportPaymentTransaction.cs
@@ -16,7 +16,7 @@
         private readonly IImportNotificationTransactionCalculator transactionCalculator;
         private readonly IImportNotificationAssessmentRepository assessmentRepository;
 
-        public ImportPaymentTransaction(IImportNotificationTransactionRepository transactionRepository, 
+        public ImportPaymentTransaction(IImportNotificationTransactionRepository transactionRepository,
             IImportNotificationTransactionCalculator transactionCalculator,
             IImportNotificationAssessmentRepository assessmentRepository)
         {
@@ -31,12 +31,12 @@
             var transaction = ImportNotificationTransaction.PaymentRecord(notificationId, date, amount,
                 paymentMethod, receiptNumber, comments);
 
-            var balance = await transactionCalculator.Balance(transaction.NotificationId)
-                - transaction.Credit.GetValueOrDefault()
-                + transaction.Debit.GetValueOrDefault();
-
-            var transactions = (await transactionRepository.GetTransactions(transaction.NotificationId)).ToList();
+            // Build the complete transaction list including the new (unsaved) transaction
+            // so that balance and CalculatePaymentReceivedDate use the same consistent data.
+            var transactions = (await transactionRepository.GetTransactions(notificationId)).ToList();
             transactions.Add(transaction);
+
+            var balance = await CalculateBalance(notificationId, transactions);
 
             var paymentDate = CalculatePaymentReceivedDate(transactions, balance);
 
@@ -48,19 +48,27 @@
         public async Task Delete(Guid notificationId, Guid transactionId)
         {
             var transaction = await transactionRepository.GetById(transactionId);
-            
-            var balance = await transactionCalculator.Balance(transaction.NotificationId)
-                + transaction.Credit.GetValueOrDefault()
-                - transaction.Debit.GetValueOrDefault();
 
-            var transactions = (await transactionRepository.GetTransactions(transaction.NotificationId)).ToList();
+            // Build the transaction list with the target transaction removed
+            // so that balance and CalculatePaymentReceivedDate use the same consistent data.
+            var transactions = (await transactionRepository.GetTransactions(notificationId)).ToList();
             transactions.RemoveAll(t => t.Id == transactionId);
+
+            var balance = await CalculateBalance(notificationId, transactions);
 
             var paymentDate = CalculatePaymentReceivedDate(transactions, balance);
 
-            await UpdatePaymentReceivedDate(paymentDate, transaction.NotificationId);
+            await UpdatePaymentReceivedDate(paymentDate, notificationId);
 
             await transactionRepository.DeleteById(transactionId);
+        }
+
+        private async Task<decimal> CalculateBalance(Guid notificationId, IEnumerable<ImportNotificationTransaction> transactions)
+        {
+            var totalBillable = await transactionCalculator.TotalBillable(notificationId);
+            var netPaid = transactions.Sum(t => t.Credit.GetValueOrDefault() - t.Debit.GetValueOrDefault());
+
+            return totalBillable - netPaid;
         }
 
         private static DateTime? CalculatePaymentReceivedDate(IEnumerable<ImportNotificationTransaction> transactions, decimal balance)


### PR DESCRIPTION
Import notifications that had been fully paid were incorrectly displaying as having an outstanding partial payment. The PaymentReceivedDate field on ImportNotificationDates remained NULL despite the full charge being settled.

**Root Cause**

The bug was in both Save() and Delete() in: EA.Iws.Domain/ImportNotificationAssessment/Transactions/ImportPaymentTransaction.cs

Both methods calculated the balance and the transaction list from two different, inconsisten sources:

transactionCalculator.Balance() internally calls both chargeCalculator.GetValue() (the charge due) and TotalPaid() (sum of DB transactions). Because the new transaction has not yet been persisted, TotalPaid() returns a stale value. The resulting balance is therefore inconsistent with the in-memory transactions list that was passed into CalculatePaymentReceivedDate.

In certain scenarios — particularly when a payment was recorded against a notification already in a non-AwaitingPayment status such as **Objected** or **Withdrawn** — this inconsistency caused CalculatePaymentReceivedDate to return null, meaning PaymentReceivedDate was never stamped on the assessment.


_**FIX**_
A new private CalculateBalance() method was introduced in ImportPaymentTransaction that computes the balance from the same in-memory transaction list used by CalculatePaymentReceivedDate:

_**Data Fix**_

A SQL data correction script needs to be executed against the database to backfill PaymentReceivedDate for all 33+ affected notifications using the same logic as CalculatePaymentReceivedDate. Records where the charge due could not be determined (missing shipment data) were flagged for manual review separately.